### PR TITLE
WIP Theme support

### DIFF
--- a/plugins/assets/assets.py
+++ b/plugins/assets/assets.py
@@ -32,7 +32,10 @@ except ImportError:
 def add_jinja2_ext(pelican):
     """Add Webassets to Jinja2 extensions in Pelican settings."""
 
-    pelican.settings['JINJA_EXTENSIONS'].append(AssetsExtension)
+    if 'JINJA_ENVIRONMENT' in pelican.settings:
+        pelican.settings['JINJA_ENVIRONMENT']['extensions'].append(AssetsExtension)
+    else:
+        pelican.settings['JINJA_EXTENSIONS'].append(AssetsExtension)
 
 
 def create_assets_env(generator):
@@ -67,6 +70,15 @@ def register():
     if webassets:
         signals.initialized.connect(add_jinja2_ext)
         signals.generator_init.connect(create_assets_env)
+        
+        try:
+            import cssmin
+        except ImportError:
+            @webassets.filter.register_filter
+            class _CssminDummy(webassets.filter.Filter):
+                name = 'cssmin'
+                def output(self, _in, out, **kw):
+                    out.write(_in.read())
     else:
         logger.warning('`assets` failed to load dependency `webassets`.'
                        '`assets` plugin not loaded.')

--- a/themes/rusted/static/css/main.scss
+++ b/themes/rusted/static/css/main.scss
@@ -11,18 +11,42 @@ $base-line-height: 1.5;
 
 $spacing-unit:     30px;
 
-$text-color:       #444;
-$background-color: #fdfdfd;
-$brand-color:      #2a7ae2;
-
-$grey-colour:       #828282;
-$grey-colour-light: lighten($grey-colour, 40%);
-$grey-colour-dark:  darken($grey-colour, 25%);
-
 $on-palm:          600px;
 $on-laptop:        800px;
 
+// Fixed colors
+$brand-color:       var(--brand);
+$grey-colour:       #828282;
+$text-color:        var(--fg);
+$grey-colour-dark:  var(--grey-fg);
+$grey-colour-light: var(--grey-bg);
+$background-color:  var(--bg);
 
+// Theme-dependent colors
+$gray-light:   lighten($grey-colour, 40%);
+$gray-dark:    darken($grey-colour, 25%);
+$gray-lighter: #fdfdfd;
+$gray-darker:  #444;
+$brand-dark:    #2a7ae2;
+$brand-light:   lighten($blue-dark, 25%);
+
+:root {
+    --brand:   #{$brand-dark};
+    --fg:      #{$gray-darker};
+    --grey-fg: #{$gray-dark};
+    --grey-bg: #{$gray-light};
+    --bg:      #{$gray-lighter};
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --brand:   #{$brand-light};
+        --fg:      #{$gray-lighter};
+        --grey-fg: #{$gray-light};
+        --grey-bg: #{$gray-dark};
+        --bg:      #{$gray-darker};
+    }
+}
 
 // Using media queries with like this:
 // @include media-query($palm) {


### PR DESCRIPTION
Needs work to support links and code, but first I wanted to know if the approach is OK:

Since this is a dynamic property, I use CSS variables to avoid having to duplicate all rules using a variable inside of a @media block. I renamed the dynamic colors to a more semantic gradient of 5 greys and a brand color.

Honestly we can probably leave the brand color static, or we reuse it for links. Also the primary button doesn’t seem to use the brand color at all anyway?

I also added some code to make it work with Python 3 (which lacks cssmin) and newer Pelican versions.

![grafik](https://user-images.githubusercontent.com/291575/69817182-51cb5e00-11fa-11ea-9612-14dac9851612.png)
