### PR TITLE
Add paper link

### DIFF
--- a/drafts/2020-03-14-this-week-in-rust.md
+++ b/drafts/2020-03-14-this-week-in-rust.md
@@ -16,6 +16,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ## News & Blog Posts
 
+- [LLHD: Rust is used to drive research in Hardware Design Languages](https://arxiv.org/pdf/2004.03494) (scientific paper)
+
 # Crate of the Week
 
 This week's crate is [explaine.rs](https://github.com/jrvidal/explaine.rs), an interactive Rust syntax playground.


### PR DESCRIPTION
Add a link to the LLHD paper, which is using Rust as a platform for hardware language research (https://arxiv.org/abs/2004.03494).

Thanks!