### PR TITLE
Add Rust and AWS Lambda blog post

### DIFF
--- a/drafts/2020-04-28-this-week-in-rust.md
+++ b/drafts/2020-04-28-this-week-in-rust.md
@@ -16,6 +16,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ## News & Blog Posts
 
+* [Data Ingestion with Rust and AWS Lambda](http://jamesmcm.github.io/blog/2020/04/19/data-engineering-with-rust-and-aws-lambda/#en)
+
 # Crate of the Week
 
 This week's crate is [regex2fat](https://github.com/8051Enthusiast/regex2fat), a program to convert a regular expression into a decidedly nonstandard FAT32 file system.


### PR DESCRIPTION
This is a blog post I wrote covering my first experience deploying Rust to AWS Lambda - converted to an example so the readers can follow along. 

The non-trivial parts covered are:

* Using a custom deserialiser for some of the fields
* Converting Excel dates (from Calamine) to chrono::NaiveDate
* Getting SSL to work with Redshift
* Cross-compiling with OpenSSL on OS X