### PR TITLE
Add ALMA PR to Calls For Participation

### DIFF
--- a/drafts/2020-04-28-this-week-in-rust.md
+++ b/drafts/2020-04-28-this-week-in-rust.md
@@ -35,6 +35,7 @@ Some of these tasks may also have mentors available, visit the task page for mor
 
 * [Compiler Explorer: Bytes support for Rust](https://github.com/mattgodbolt/compiler-explorer/issues/1925).
 * [rlua is looking for maintainers](https://github.com/kyren/rlua/issues/172).
+* [ALMA: Add flag to install to partition instead of formatting disk](https://github.com/r-darwish/alma/issues/46).
 
 If you are a Rust project owner and are looking for contributors, please submit tasks [here][guidelines].
 


### PR DESCRIPTION
[ALMA](https://github.com/r-darwish/alma) is a Rust application to create persistent Arch Linux Live USB installations.

There are many open issues, this is what I considered to be the most important (mainly to raise awareness in the Rust developer community, as many readers will be Arch Linux users).

Note I am a significant contributor to ALMA, but not the project founder.