### PR TITLE
Fix the link to Crust of Rust by Jon Gjengset

### DIFF
--- a/content/2020-04-29-this-week-in-rust.md
+++ b/content/2020-04-29-this-week-in-rust.md
@@ -25,7 +25,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 * [Memory efficient serialization of tagged union](https://robinmoussu.gitlab.io/blog/post/binary_serialisation_of_enum/).
 * [Unpacking Serde](https://www.reddit.com/r/rust/comments/g6ubuv/unpacking_serde_a_series_of_presentations_i_made/).
 * [video] [Rust stream: ownership, closures, and threads - oh my](https://www.youtube.com/watch?v=2mwwYbBRJSo).
-* [Crust of Rust: lifetime annotations](https://docs.google.com/spreadsheets/d/15pqsOlwc2eBXNRV0GJP7Taa3NnFi5kMFpmyVerONsf8/edit#gid=853276561).
+* [video] [Crust of Rust: lifetime annotations](https://www.youtube.com/watch?v=rAl-9HwD858).
 * [First impressions on Rust and WebAssembly](https://deedone.github.io/posts/rust-wasm/).
 * [From Rust to WebAssembly: Building an interactive note-taking web app with Actix & Yew](https://www.luu.io/posts/lenote).
 * [Rust’s future: internal execution](https://blog.knoldus.com/rusts-future-internal-execution/).


### PR DESCRIPTION
The link in the recent issue points to a spreadsheet instead of the actual
YouTube video. It also should be annotated with the [video] tag like the link
above it.