### PR TITLE
[Blog] Add async introduction blog post

### DIFF
--- a/drafts/2020-05-12-this-week-in-rust.md
+++ b/drafts/2020-05-12-this-week-in-rust.md
@@ -16,6 +16,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ## News & Blog Posts
 
+* [A practical introduction to async programming in Rust](http://jamesmcm.github.io/blog/2020/05/06/a-practical-introduction-to-async-programming-in-rust/#en)
+
 # Crate of the Week
 
 This week's crate is [WinRT-rs](https://github.com/microsoft/winrt-rs), Microsoft™'s official WinRT API for Rust.


### PR DESCRIPTION
I wrote this blog post on an introduction to async programming, mainly aimed at beginners to async programming - demonstrating different execution scenarios with a simple example.