### PR TITLE
[News] Add entry for Romt release

### DIFF
--- a/drafts/2020-05-12-this-week-in-rust.md
+++ b/drafts/2020-05-12-this-week-in-rust.md
@@ -16,7 +16,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ## News & Blog Posts
 
-* [Romt - Rust Offline Mirror Tool](https://github.com/drmikehenry/romt)
+* [Romt "Rust Offline Mirror Tool" Released](https://github.com/drmikehenry/romt)
 
 # Crate of the Week
 

--- a/drafts/2020-05-12-this-week-in-rust.md
+++ b/drafts/2020-05-12-this-week-in-rust.md
@@ -16,6 +16,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ## News & Blog Posts
 
+* [Romt - Rust Offline Mirror Tool](https://github.com/drmikehenry/romt)
+
 # Crate of the Week
 
 This week's crate is [WinRT-rs](https://github.com/microsoft/winrt-rs), Microsoft™'s official WinRT API for Rust.


### PR DESCRIPTION
Add ~~blog post~~ news entry for new tool release: https://github.com/drmikehenry/romt

> Romt (Rust Offline Mirror Tool) aids in using the Rust programming language in an offline context. 