### PR TITLE
adds code of conduct file linking to Rust community CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+All contributors are expected to follow the [Rust Community Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct).


### PR DESCRIPTION
I've found it to be a good practice to have a Code of Conduct file (even one that links to a larger CoC) in any GitHub repo, just in case. This links directly to the Rust Community CoC. While there have not been any incidents that I know of so far, it's good to have this defined before something happens and makes it easier to respond when the time comes.

Signed-off-by: Nell Shamrell <nellshamrell@gmail.com>