### PR TITLE
A txt file to have a backup links of previous TWiR

### DIFF
--- a/links.txt
+++ b/links.txt
@@ -1,0 +1,3709 @@
+Number: 96  Date: 2015-09-14 
+
+* [Why Rust?](http://www.oreilly.com/programming/free/files/why-rust.pdf). Free ebook by Jim Blandy (published by O’Reilly Media).
+* [“The Rust Programming Language” to be published by No Starch Press](http://words.steveklabnik.com/the-rust-programming-language-will-be-published-by-no-starch-press). All profits from the book will go to [OpenHatch](http://openhatch.org).
+* [Parser Combinator Experiments in Rust - Part 3: Performance and impl Trait](https://m4rw3r.github.io/parser-combinator-experiments-part-3/).
+* [Building a Build System: Bazel reaches Beta](http://google-opensource.blogspot.com.es/2015/09/building-build-system-bazel-reaches-beta.html). Includes support for Rust.
+
+Number: 97  Date: 2015-09-21 
+
+* [Asynchronous IO in Rust](https://blog.skcript.com/asynchronous-io-in-rust-36b623e7b965).
+* [An introduction to timely dataflow](https://github.com/frankmcsherry/blog/blob/7a1174e80134c8ce5338d5c62864a2aae835da04/posts/2015-09-14.md). Dataflow computational model written in Rust.
+* [An introduction to timely dataflow, part 2.](https://github.com/frankmcsherry/blog/blob/master/posts/2015-09-18.md). Writing super-powerful operators that do whatever you want to the streams.
+* [A Pythonista's irresistible attraction to Rust](http://hardcoded.net/articles/pythonistas-irresistible-attraction-rust).
+* [Python Modules in Rust](https://ehiggs.github.io/2015/07/Python-Modules-In-Rust/).
+* [Fine-grained timing and energy profiling in Servo](http://blog.servo.org/2015/09/11/timing-energy/).
+* [Seeking Compilation-Independent Type IDs in Rust](http://davidlegare.ghost.io/seeking-compilation-independent-type-ids-in-rust/).
+* [Running Rust code on the 3DS 2: Electric Boogaloo](http://www.idolagames.com/running-rust-code-on-the-3ds-2-electric-boogaloo/).
+* [Specialize to reuse](https://aturon.github.io/blog/2015/09/18/reuse/). [Specialization](https://github.com/rust-lang/rfcs/pull/1210) supports clean, inheritance-like patterns out of the box. This post explains how, and discusses the interaction with the “virtual structs” saga.
+* [Eliminating branches in Rust](http://kamalmarhubi.com/blog/2015/09/15/eliminating-branches-in-rust-for-fun-but-not-much-profit/).
+* [Rust and the Monad trait - Not just higher kinded types](https://m4rw3r.github.io/rust-and-monad-trait/).
+
+Number: 98  Date: 2015-09-28 
+
+* [If you use unsafe, you should be using compiletest](https://erickt.github.io/blog/2015/09/22/if-you-use-unsafe/).
+* [Running Rust on the Rumprun unikernel](https://gandro.github.io/2015/09/27/rust-on-rumprun/).
+* [Survey of licenses used by Rust projects on crates.io](http://paul.woolcock.us/posts/crates-io-license-survey.html).
+* [An introduction to timely dataflow, part 3](https://github.com/frankmcsherry/blog/blob/master/posts/2015-09-21.md). Learn more about timely dataflow by writing a breadth-first search on random graphs.
+* [These weeks in Servo 34](http://blog.servo.org/2015/09/21/twis-34/).
+* [Get data from a URL in Rust](http://hermanradtke.com/2015/09/21/get-data-from-a-url-rust.html).
+* [Debuger state machine in Rust](http://system.joekain.com/2015/09/16/rust-state-machine.html).
+
+Number: 99  Date: 2015-10-05 
+
+* [When Rust makes sense, or the state of typed languages](https://m50d.github.io/2015/09/28/when-rust-makes-sense.html).
+* [podcast] [Rusty radio: Episode 4](http://rustyrad.io/podcast/4/). Raft, Paxos, and Distributed Systems in Rust.
+* [This week in Servo 35](http://blog.servo.org/2015/09/28/twis-35/).
+* [Resurrecting impl Trait](https://aturon.github.io/blog/2015/09/28/impl-trait/).
+* [Combining Rust and Haskell](http://tab.snarc.org/posts/haskell/2015-09-29-rust-with-haskell.html).
+* [video] [Using Rust with Ruby, a deep dive with Yehuda Katz](https://www.youtube.com/watch?v=IqrwPVtSHZI).
+* [How to print a struct in Rust](https://joelmccracken.github.io/entries/how-to-print-a-struct-in-rust/).
+* [Trying Rust for web services](https://blog.wearewizards.io/trying-rust-for-web-services).
+* [An introduction to differential dataflow, part 1](https://github.com/frankmcsherry/blog/blob/master/posts/2015-09-29.md).
+* [Experiences building an OS in Rust](https://mostlytyped.com/posts/experiences-building-an-os-in-ru).
+* [Ownership is theft: Experiences building an embedded OS in Rust](http://amitlevy.com/papers/tock-plos2015.pdf).
+* [Rust faster!](https://llogiq.github.io/2015/10/03/fast.html)
+* [podcast] [New Rustacean podcast episode 01](http://www.newrustacean.com/show_notes/e001/index.html). Documentation in general, and `rustdoc` and `cargo doc` in particular.
+* [Rusty queens](http://jd.ekstrandom.net/blog/2015/10/rusty-queens). An n-queens solver in Rust.
+
+Number: 100  Date: 2015-10-12 
+
+* [Safety = Freedom](https://llogiq.github.io/2015/10/05/safety-freedom.html).
+* [This week in Redox 1](http://www.redox-os.org/news/this-week-in-redox-1/). Redox is an upcoming OS written in Rust.
+* [This week in Servo 36](http://blog.servo.org/2015/10/05/twis-36/).
+* [Conference report: Friendly, diverse Rust Camp](http://techwhirl.com/conference-report-friendly-diverse-rust-camp/).
+* [Neither necessary nor sufficient](https://ruudvanasseldonk.com/2015/10/06/neither-necessary-nor-sufficient) - why Rust shipped without GC.
+* [Rustfmt-ing Rust](http://www.ncameron.org/blog/rustfmt-ing-rust/).
+* [Virtual structs part 4: Extended enums and thin traits](http://smallcultfollowing.com/babysteps/blog/2015/10/08/virtual-structs-part-4-extended-enums-and-thin-traits/).
+* [Macros](http://www.ncameron.org/blog/macros/). Plans on an overhaul of the syntax extension and macro systems in Rust.
+* [Lints that collect data per crate](https://llogiq.github.io/2015/10/09/lint-data.html).
+* [Stuff the identity function does (in Rust)](https://bluss.github.io/rust/fun/2015/10/11/stuff-the-identity-function-does/).
+* [Rust in detail: Writing scalable chat service from scratch](https://nbaksalyar.github.io/2015/07/10/writing-chat-in-rust.html).
+* [Formalizing Rust](https://www.ralfj.de/blog/2015/10/12/formalizing-rust.html).
+
+Number: 101  Date: 2015-10-19 
+
+* [The little book of Rust macros](https://danielkeep.github.io/tlborm/).
+* [Rust and IDEs](https://www.rust-lang.org/ides.html). The plan for better integration of Rust with IDEs.
+* [This week in Redox 2](http://www.redox-os.org/news/this-week-in-redox-2/). Redox is an upcoming OS written in Rust.
+* [This Week In Servo 37](http://blog.servo.org/2015/10/12/twis-37/).
+* [Rust to the rescue (of Ruby)](https://medium.com/@fbzga/rust-to-the-rescue-of-ruby-2067f5e1dc25). Call Rust code from Ruby.
+* [Hacking Servo for noobs](https://gist.github.com/paulrouget/2f00941e6e82aeecad23).
+* [Building an SQL database with 10 Rust beginners](https://lukaskalbertodt.github.io/2015/10/09/building-an-sql-database-with-10-rust-beginners.html).
+* [Using a Rust DLL from C#](http://www.loekvandenouweland.com/content/using-rust-code-from-csharp).
+* [Creating a C API for a Rust library](http://www.joshmatthews.net/blog/2015/10/creating-a-c-api-for-a-rust-library/).
+* [A simple link checker built with Rust](http://antonyh.co.uk/2015/10/a-simple-link-checker-built-with-rust/).
+
+Number: 102  Date: 2015-10-26 
+
+* [Design patterns in Rust](http://www.ncameron.org/blog/design-patterns-in-rust/).
+* [Managing connection state with mio](http://hermanradtke.com/2015/10/23/managing-connection-state-with-mio-rust.html).
+* [Writing an OS in Rust](http://blog.phil-opp.com/).
+* [Good practices for writing Rust libraries](https://pascalhertleif.de/artikel/good-practices-for-writing-rust-libraries/).
+* [Rust and Swift](http://www.chriskrycho.com/2015/rust-and-swift-i.html).
+* [This week in Redox 3](http://www.redox-os.org/news/this-week-in-redox-3/).
+* [This week in Servo 38](http://blog.servo.org/2015/10/19/twis-38/).
+* [Things I learned from Rust](https://dfockler.github.io/#learned-rust).
+* [Messy error handling in Rust with `try!`](http://mortoray.com/2015/10/21/messy-error-handling-in-rust-with-try/).
+* [podcast] [New Rustacean podcast episode 02](http://www.newrustacean.com/show_notes/e002/). The `struct` data type constructor, and the basics of Rust's "ownership" concept and "borrowing" and "moving".
+* [podcast] [New Rustacean podcast episode 03](http://www.newrustacean.com/show_notes/e003/). Enumerated (`enum`) types, pattern matching, and meaningful return values.
+* [Simple_parallel 0.3: Revisiting k-NN](https://huonw.github.io/blog/2015/10/simple_parallel-revisiting-knn/).
+
+Number: 103  Date: 2015-11-02 
+
+* [This week in Servo 39](http://blog.servo.org/2015/10/26/twis-39/).
+* [This week in Redox 4](http://www.redox-os.org/news/this-week-in-redox-4/).
+* [Rreverrse debugging](https://huonw.github.io/blog/2015/10/rreverse-debugging/). Debugging Rust applications with rr.
+* [Piston-Meta](http://blog.piston.rs/2015/10/28/new-meta-language/). A DSL parsing library for human readable text documents.
+* [Let's uncomplicate!](http://lez-uncomplicate.blogspot.in/2015/10/understanding-rust-build-system-log.html). Demistifying the `rustc` build process.
+* [Using Resque with Rust](http://julienblanchard.com/2015/using-resque-with-rust/).
+* [Rust lifetimes](http://www.charlesetc.com/rust/2015/10/29/).
+
+Number: 104  Date: 2015-11-09 
+
+* There were two major breaking events in the ecosystem this week due to [a libc upgrade](https://www.reddit.com/r/rust/comments/3s43n4/discussion_lessons_learned_following_the_recent) and [a winapi upgrade](https://github.com/retep998/winapi-rs/issues/238).
+* [Bare metal Rust: Low-level CPU I/O ports](http://www.randomhacks.net/2015/11/09/bare-metal-rust-cpu-port-io/).
+* [Macros in Rust - Part 1](http://ncameron.org/blog/macros-in-rust-pt1/).
+* [Macros in Rust - Part 2](http://www.ncameron.org/blog/macros-in-rust-pt2/). Procedural macros.
+* [Macros in Rust - Part 3](http://www.ncameron.org/blog/macros-in-rust-pt3/). Macro hygiene in Rust.
+* [Using rustfmt in Vim](http://johannh.me/blog/rustfmt-vim.html).
+* [Writing my first Rust crate: jsonwebtoken](https://blog.wearewizards.io/writing-my-first-rust-crate-jsonwebtoken).
+* [Learning to 'try!' things in Rust](http://www.jonathanturner.org/2015/11/learning-to-try-things-in-rust.html).
+* [video] [Concurrency in Rust](https://vimeo.com/144809407).
+* [This week in Redox 5](http://www.redox-os.org/news/this-week-in-redox-5/).
+* [This week in Servo 40](http://blog.servo.org/2015/11/02/twis-40/).
+
+Number: 105  Date: 2015-11-16 
+
+* [**Redox is serious**](http://dictator.redox-os.org/index.php?controller=post&action=view&id_post=17). Redox is an upcoming OS written in Rust.
+* [Index 1,600,000,000 keys with Automata and Rust](http://blog.burntsushi.net/transducers/).
+* [Writing an OS in Rust: Allocating frames](http://os.phil-opp.com/allocating-frames.html).
+* [Making Popcorn: Adding a disk to a Rust Rumprun Unikernel](https://polyfractal.com/post/adding-a-disk-to-a-rust-rumprun-unikernel/).
+* [Rust in detail: Sending and receiving messages](https://nbaksalyar.github.io/2015/11/09/rust-in-detail-2.html).
+* [Rust impressions from a C++/D programmer, part 1](https://atilanevesoncode.wordpress.com/2015/11/09/rust-impressions-from-a-cd-programmer-part-1/).
+* [Rust impressions from a C++/D programmer, part 2](https://atilanevesoncode.wordpress.com/2015/11/16/rust-impressions-from-a-cd-programmer-part-2/).
+* [Bare metal Rust 2: Retarget your compiler so interrupts are not evil](http://www.randomhacks.net/2015/11/11/bare-metal-rust-custom-target-kernel-space/).
+* [This week in Servo 41](http://blog.servo.org/2015/11/09/twis-41/).
+
+Number: 106  Date: 2015-11-23 
+
+* [Rust on AWS Lambda](http://julienblanchard.com/2015/rust-on-aws-lambda/).
+* [Async IO for Rust (part II)](https://medium.com/@paulcolomiets/async-io-for-rust-part-ii-33b9a7274e67).
+* [GC and Rust Part 0: Garbage collection background](http://blog.pnkfx.org/blog/2015/10/27/gc-and-rust-part-0-how-does-gc-work/).
+* [GC and Rust Part 1: Specifying the problem](http://blog.pnkfx.org/blog/2015/11/10/gc-and-rust-part-1-specing-the-problem/).
+* [Lessons learned from Rust: The Result Monad in Ruby](http://www.codethatgrows.com/lessons-learned-from-rust-the-result-monad/).
+* [Bare Metal Rust 3: Configure your PIC to handle interrupts correctly](http://www.randomhacks.net/2015/11/16/bare-metal-rust-configure-your-pic-interrupts/).
+* [`concat_idents!` and macros in ident position](http://ncameron.org/blog/untitledconcat_idents-and-macros-in-ident-position/).
+* [This week in Piston](http://blog.piston.rs/2015/11/17/what-is-happening/).
+* [This week in Servo 42](http://blog.servo.org/2015/11/16/twis-42/).
+* [This week in Redox OS 6](http://www.redox-os.org/news/this-week-in-redox-6/).
+* [Russian] [Software render in Rust: Cubic texture](http://reangdblog.blogspot.com/2015/11/software-render-rust.html). ([Translated version](https://translate.google.com/translate?u=http://reangdblog.blogspot.com/2015/11/software-render-rust.html)).
+
+Number: 107  Date: 2015-11-30 
+
+* [Announcing Diesel — A safe, extensible ORM and query builder for Rust](https://medium.com/@sgrif/announcing-diesel-a-safe-extensible-orm-and-query-builder-for-rust-fdf57966a16c).
+* [Where are you From::from, And what have you turned Into::into](https://llogiq.github.io/2015/11/27/from-into.html)? When and for what to use `From` and `Into` traits.
+* [Experimenting with Rust](https://www.polidea.com/blog/Experimenting_with_Rust/).
+* [Language of the month: Rust](https://gergely.imreh.net/blog/2015/11/language-of-the-month-rust/).
+* [Macro hygiene in all its guises and variations](http://www.ncameron.org/blog/macro-hygiene-in-all-its-guises-and-variations/).
+* [Macro plans, overview](http://www.ncameron.org/blog/macro-plans-overview/). An overview of the changes that Nick plans to propose for the macro system.
+* [Parser Combinators: The road to Chomp 0.1](https://m4rw3r.github.io/parser-combinators-road-chomp-0-1/).
+
+Number: 108  Date: 2015-12-07 
+
+* [Rustaceans: Please keep a changelog](https://blog.dbrgn.ch/2015/12/1/rust-crates-keep-a-changelog/)!
+* [Building a simple JIT in Rust](http://www.jonathanturner.org/2015/12/building-a-simple-jit-in-rust.html).
+* [Build an API in Rust with JWT authentication using Nickel.rs](https://auth0.com/blog/2015/11/30/build-an-api-in-rust-with-jwt-authentication-using-nickelrs/).
+* [Using Wayland from Rust, part 1](http://blog.levans.fr/rust_wayland_1-en.html).
+* [Language of the month: Rust, the results](https://gergely.imreh.net/blog/2015/12/lotm-rust-results/).
+* [embed_lang - An embeddable language written in Rust](https://marwes.github.io/2015/12/06/embed_lang-An-embeddable-language-written-in-Rust.html).
+* [Implementing a SuperCollider UGen in Rust](http://www.andrewchristophersmith.com/blog/implementing_a_supercollider_external_in_rust/).
+* [This week in Redox OS 7](http://www.redox-os.org/news/this-week-in-redox-7/).
+* [This week in Servo 43](http://blog.servo.org/2015/11/30/twis-43/).
+
+Number: 109  Date: 2015-12-14 
+
+* [Building an iOS app in Rust, Part 3](https://www.bignerdranch.com/blog/building-an-ios-app-in-rust-part-3/). Passing owned objects between Rust and iOS.
+* [Writing an OS in Rust: Accessing and modifying page tables](http://os.phil-opp.com/modifying-page-tables.html). Part of the series [Writing an OS in Rust](http://os.phil-opp.com/).
+* [Rust programming: Creating a Phoronix reader application](https://www.gitbook.com/book/mmstick/rust-programming-phoronix-reader-how-to/details)
+* [Macro plans - syntax](http://www.ncameron.org/blog/macro-plans-syntax/). Proposal to improve the syntax for Rust macros.
+* [Zero-runtime-cost mixed list in Rust](https://nercury.github.io/rust/interesting/2015/12/12/typed-arrays.html).
+* [ArcadeRS 1.10: Asteroid attack!](https://jadpole.github.io/arcaders/arcaders-1-10/). Part of the series [ArcadeRS 1.0: The project](https://jadpole.github.io/arcaders/arcaders-1-0/) - a series whose objective is to explore the Rust programming language and ecosystem through the development of a simple, old-school shooter.
+* [Rust profiling with instruments and FlameGraph on OSX: CPU/Time](http://carol-nichols.com/2015/12/09/rust-profiling-on-osx-cpu-time/).
+* [Type-Level Shenanigans](https://llogiq.github.io/2015/12/12/types.html).
+* [This Week in Redox OS 8](http://www.redox-os.org/news/this-week-in-redox-8/).
+
+Number: 110  Date: 2015-12-21 
+
+* [What one must understand to be productive with Rust](https://medium.com/@ericdreichert/what-one-must-understand-to-be-productive-with-rust-e9e472116728).
+* [Rayon: Data parallelism in Rust](http://smallcultfollowing.com/babysteps/blog/2015/12/18/rayon-data-parallelism-in-rust/).
+* [Programming with Rust](http://hackaday.com/2015/12/18/programming-with-rust/). Rust for hardware hackers.
+* [Rendering an animation in Rust](http://www.willusher.io/2015/12/16/rendering-an-animation-in-rust/).
+* [Procedural macros, framework](http://www.ncameron.org/blog/procedural-macros-framework/). Nick's continued efforts for a better macro system in Rust.
+* [Differential geometry in Rust](http://ebvalaim.mydevil.net/en/2015/12/18/differential-geometry-in-rust/).
+* [Adding community-driven Wayland support to Servo](http://blogs.s-osg.org/community-driven-wayland-support-servo/).
+* [Surfaces and signatures: Component privacy versus dependence](http://blog.pnkfx.org/blog/2015/12/19/signatures-and-surfaces-thoughts-on-privacy-versus-dependency/).
+* [This week in Redox OS 9](http://www.redox-os.org/news/this-week-in-redox-9/).
+
+Number: 111  Date: 2015-12-28 
+
+* [Neon: Node + Rust = 💖](http://calculist.org/blog/2015/12/23/neon-node-rust/). Neon is a set of APIs and tools for making it super easy to write native Node modules in Rust.
+* [podcast] [New Rustacean podcast episode 08](http://www.newrustacean.com/show_notes/e008/). Generics, traits, and shared behavior in Rust.
+
+Number: 112  Date: 2016-01-04 
+
+* [This week in Servo 45](http://blog.servo.org/2015/12/28/twis-45/).
+* [What is happening in Piston 2](http://blog.piston.rs/2015/12/31/what-is-happening-2/).
+* [Async IO in Rust (part III)](https://medium.com/@paulcolomiets/async-io-in-rust-part-iii-cbfd10f17203).
+* [Writing an OS in Rust: Remap the Kernel](http://os.phil-opp.com/remap-the-kernel.html). Part of the series [Writing an OS in Rust](http://os.phil-opp.com/).
+* [Aha! Understanding lifetimes in Rust](http://codrspace.com/buntine/aha-understanding-lifetimes-in-rust/).
+* [Distributed rendering with Rust and Mio](http://www.willusher.io/2016/01/02/distributed-rendering-with-rust-and-mio/).
+* [Racer progress update](http://phildawes.net/blog/2015/12/29/racer-update-6/). Changes and notes around Racer 1.1.0 release.
+
+Number: 113  Date: 2016-01-11 
+
+* [My thoughts on Rust in 2016](http://www.ncameron.org/blog/my-thoughts-on-rust-in-2016/). By Nick Cameron.
+* [Making your open-source project newcomer-friendly](https://manishearth.github.io/blog/2016/01/03/making-your-open-source-project-newcomer-friendly/).
+* [This Week In Servo 46](http://blog.servo.org/2016/01/04/twis-46/).
+* [Compiling Rust to an Android target](https://ghotiphud.github.io/rust/android/cross-compiling/2016/01/06/compiling-rust-to-android.html).
+* [ArcadeRS 1.11: Shooting bullets](https://jadpole.github.io/arcaders/arcaders-1-11/). Part of the series [ArcadeRS 1.0: The project](https://jadpole.github.io/arcaders/arcaders-1-0/) - a series whose objective is to explore the Rust programming language and ecosystem through the development of a simple, old-school shooter.
+* [GC and Rust part 2: The roots of the problem](http://blog.pnkfx.org/blog/2016/01/01/gc-and-rust-part-2-roots-of-the-problem/).
+* [slides] [Why I ❤ Rust](https://speakerdeck.com/jvns/why-i-rust). By Julia Evans.
+* [Discovering hardware topology in Rust](http://nitschinger.at/Discovering-Hardware-Topology-in-Rust/).
+* [The scope of `unsafe`](https://www.ralfj.de/blog/2016/01/09/the-scope-of-unsafe.html).
+* [Two weeks of Rust - building a Memcache clone](http://www.matusiak.eu/numerodix/blog/2016/1/10/two-weeks-rust/).
+* [Abstract return types, aka `impl Trait`](http://www.ncameron.org/blog/abstract-return-types-aka-%60impl-trait%60/).
+* [RustBelt: Logical Foundations for the Future of Safe Systems Programming](http://plv.mpi-sws.org/rustbelt/).
+
+Number: 114  Date: 2016-01-18 
+
+* [Guide: Contributing to the Rust compiler](http://gregchapple.com/contributing-to-the-rust-compiler/).
+* [A type-safe and zero-allocation library for reading and navigating ELF files](http://www.ncameron.org/blog/a-type-safe-and-zero-allocation-library-for-reading-and-navigating-elf-files/).
+* [podcast] [New Rustacean podcast episode 09](http://www.newrustacean.com/show_notes/e009/). Getting into the nitty-gritty with Rust's traits.
+* [ArcadeRS 1.12: Brawl, at last](https://jadpole.github.io/arcaders/arcaders-1-12/)! Part of the series [ArcadeRS 1.0: The project](https://jadpole.github.io/arcaders/arcaders-1-0/) - a series whose objective is to explore the Rust programming language and ecosystem through the development of a simple, old-school shooter.
+* [Raspberry Pi bare metal programming with Rust](https://blog.thiago.me/raspberry-pi-bare-metal-programming-with-rust/).
+* [This week in Servo 47](http://blog.servo.org/2016/01/11/twis-47/).
+* [This week in Redox OS 10](http://www.redox-os.org/news/this-week-in-redox-10/).
+
+Number: 115  Date: 2016-01-25 
+
+* [Rust, BigData and my laptop](http://www.poumeyrol.fr/2016/01/15/Awkward-zone/).
+* [pdf][You can't spell trust without Rust](https://cdn.rawgit.com/Gankro/thesis/master/thesis.pdf). Analysis of the semantics and expressiveness of Rust’s type system.
+* [Libmacro - an API for procedural macros to interact with the compiler](http://www.ncameron.org/blog/libmacro/).
+* [Rust and the Blub Paradox](http://www.jonathanturner.org/2016/01/rust-and-blub-paradox.html). And the [follow-up](http://www.jonathanturner.org/2016/01/rethinking-the-blub-paradox.html).
+* [video] [Ferris Makes Emulators](https://www.youtube.com/channel/UC4mpLlHn0FOekNg05yCnkzQ/videos). Live stream of Ferris developing a N64 emulator in Rust (also on [Twitch](http://www.twitch.tv/ferrisstreamsstuff/profile)).
+
+Number: 116  Date: 2016-02-01 
+
+* [The `?` operator and `try` vs `do`](https://m4rw3r.github.io/rust-questionmark-operator/). A follow-up on [Trait-based exception handling](https://github.com/rust-lang/rfcs/pull/243) RFC.
+* [Rust vs. C++: Fine-grained Performance](http://cantrip.org/rust-vs-c++.html).
+* [Stateful: A Rust experimental syntax extension for generators and more](https://erickt.github.io/blog/2016/01/27/stateful-in-progress-generators/).
+* [Rust and BigData](http://www.poumeyrol.fr/2016/01/25/The-Rust-is-in-there/).
+* [Rust Guide to CHANGELOG.md](https://medium.com/@autumn_eng/guide-to-changelog-md-in-rust-6eb349808fa4).
+* [Rules-based Network programming with Mio and Rust](http://www.lshift.net/blog/2016/01/27/rules-based-mio-chat-example/).
+* [Eliminating the Garbage Collector: The RAII Way](http://www.toptal.com/software/eliminating-garbage-collector).
+* [These weeks in Servo 48](https://blog.servo.org/2016/01/25/twis-48/).
+* [Rust for the web](https://medium.com/@eugeniyoz/restful-api-in-rust-impressions-63250d611d15). RESTful API in Rust.
+
+Number: 117  Date: 2016-02-08 
+
+* [Everything you need to know about cross compiling Rust programs](https://github.com/japaric/rust-cross).
+* [Deep learning in Rust: Baby steps](https://medium.com/@tedsta/deep-learning-in-rust-7e228107cccc).
+* [BigData & Rust, part 3](http://www.poumeyrol.fr/2016/02/01/Lets-optimize/). A comparison of data serialisation formats.
+* [Rust's memory management for C/C++ programmers](http://blog.zgtm.de/1).
+* [How Stateful cheats at analysis](https://erickt.github.io/blog/2016/01/28/stateful/). Stateful is a Rust experimental syntax extension for generators and more.
+* [This week in Servo 49](http://blog.servo.org/2016/02/01/twis-49/).
+* [This Week in Amethyst 3](https://thisweekinamethyst.wordpress.com/2016/02/01/twia-3/). Amethyst is a data-oriented game engine written in Rust.
+
+Number: 118  Date: 2016-02-15 
+
+* [Binding threads and processes to CPUs in Rust](http://nitschinger.at/Binding-Threads-And-Processes-to-CPUs-in-Rust/).
+* [The many kinds of code reuse in Rust](http://cglab.ca/~abeinges/blah/rust-reuse-and-recycle/).
+* [Code of heat conductivity](https://llogiq.github.io/2016/02/10/code.html). Llogiq on Rust's Code of Conduct.
+* [Rustic Bits](https://llogiq.github.io/2016/02/11/rustic.html). And on the small things that make code *rustic*.
+* [Why Rust's ownership/borrowing is hard](http://softwaremaniacs.org/blog/2016/02/12/ownership-borrowing-hard/en/).
+* [video] [Rust: Unlocking Systems Programming by Aaron Turon](http://www.infoq.com/presentations/rust-thread-safety).
+* [This week in Servo 50](http://blog.servo.org/2016/02/08/twis-50/).
+* [This week in Amethyst 4](https://thisweekinamethyst.wordpress.com/2016/02/08/twia-4/). Amethyst is a data-oriented game engine written in Rust.
+
+Number: 119  Date: 2016-02-22 
+
+* [Scripting in Dyon without garbage collector](http://blog.piston.rs/2016/02/21/scripting-without-garbage-collector/). Dyon is a dynamically typed programming language written in Rust.
+* [(Almost) 6 Months of Rust Runtime Performance](https://dikaiosune.github.io/almost-6-months-rust-runtime-perf.html).
+* [Embrace the glow cloud](http://www.poumeyrol.fr/2016/02/15/Embrace-the-glow-cloud/). Part #5 of a series about a BigData in Rust experiment.
+* [First steps with Rust and Java Native Interface](http://nitschinger.at/First-Steps-with-Rust-and-JNI/).
+* [Parallel iterators part 1: Foundations](http://smallcultfollowing.com/babysteps/blog/2016/02/19/parallel-iterators-part-1-foundations/).
+* [First steps towards simple and efficient parsers](https://syslog-ng.org/syslog-ng-and-rust/). Making syslog-ng parser plugins with Rust.
+* [Are we web yet? is relaunched](http://www.arewewebyet.org/news/2016/02/16/we-are-back-baby/).
+* [This week in Servo 51](http://blog.servo.org/2016/02/15/twis-51/).
+* [This week in Redox 11](http://www.redox-os.org/news/this-week-in-redox-11/).
+* [This week in Amethyst 5](https://thisweekinamethyst.wordpress.com/2016/02/15/twia-5/). Amethyst is a data-oriented game engine written in Rust.
+
+Number: 120  Date: 2016-02-29 
+
+* [Comparing Rust and Java](https://llogiq.github.io/2016/02/28/java-rust.html).
+* [Performance analysis](https://blog.ethcore.io/performance-analysis/) of Ethereum clients Parity (Rust) and Geth (Go).
+* [Programming for Servo: Experience and knowledge gained](https://nikkisquared.github.io/2016/02/22/things-ive-learned.html).
+* [Parallel iterators part 2: Producers](http://smallcultfollowing.com/babysteps/blog/2016/02/25/parallel-iterators-part-2-producers/).
+* [video] [Ferris makes emulators: Episode 6](https://www.youtube.com/watch?v=TmNfPEb-ijo). Live stream of Ferris developing a N64 emulator in Rust (also on [Twitch](http://www.twitch.tv/ferrisstreamsstuff/profile)).
+* [Query2 in timely dataflow](http://www.poumeyrol.fr/2016/02/22/Query2-in-timely/). Part #6 of a series about a BigData in Rust experiment.
+* [opinion] [Rewrite Everything In Rust](http://robert.ocallahan.org/2016/02/rewrite-everything-in-rust.html).
+* [Deciding to rewrite getaddrinfo in Rust](http://blog.dkhenry.com/2016/02/17/deciding-to-rewrite-getaddrinfo-in-rust/).
+* [Testing Rust on iOS with Travis](http://sasheldon.com/blog/2016/02/22/testing-rust-on-ios-with-travis/).
+* [Create GitHub releases with Rust using Hubcaps](https://fnordig.de/2016/02/23/create-releases-using-hubcaps-a-rust-library/).
+* [More type-level shenanigans](https://llogiq.github.io/2016/02/23/moretypes.html).
+* [Measuring Rust Runtime Performance: cargo bench vs. getrusage()](https://dikaiosune.github.io/rust-runtime-cargobench-vs-getrusage.html).
+* [The highs and lows of Rust](https://www.jimmycuadra.com/posts/the-highs-and-lows-of-rust/).
+* [This week in Amethyst 6](https://thisweekinamethyst.wordpress.com/2016/02/22/twia-6/).
+* [This week in Servo 52](http://blog.servo.org/2016/02/22/twis-52/).
+
+Number: 121  Date: 2016-03-07 
+
+* [Memory Management in Rust and Swift](https://medium.com/@itchyankles/memory-management-in-rust-and-swift-8ecda3cdf5b7).
+* [Rust and Swift](http://www.chriskrycho.com/rust-and-swift.html). An ongoing series of blog posts comparing Rust and Swift.
+* [Lambda architecture with differential dataflow](http://www.poumeyrol.fr/2016/02/29/Query2-in-differential-dataflow/). Part #7 of a series about a BigData in Rust experiment.
+* [How to use Eco](http://blog.piston.rs/2016/03/04/how-to-use-eco/). Eco is a tool for reasoning about breaking changes in Rust ecosystems.
+* [Clippy: Linting as a Service](http://www.bashy.io/news/2016/03/05/clippy-linting-as-a-service/).
+* [ASM.JS code using Rust and Emscripten](http://ashleysommer.com.au/how-to/articles/asm-js-code-using-rust-and-emscripten).
+* [video] [Ferris makes emulators: Episode 7](https://youtu.be/0GtccLHA9hc). Recorded stream of Ferris developing a N64 emulator in Rust (also on [Twitch](http://www.twitch.tv/ferrisstreamsstuff/profile)).
+* [Nice errors in LALRPOP](http://smallcultfollowing.com/babysteps/blog/2016/03/02/nice-errors-in-lalrpop/). LALRPOP is an LR(1) parser generator for Rust.
+* [This week in Servo 53](https://blog.servo.org/2016/02/29/twis-53/).
+
+Number: 122  Date: 2016-03-14 
+
+* [video] [Chrome vs Firefox vs Safari vs Servo WebRender](https://youtu.be/u0hYIRQRiws).
+* [Machine learning in Rust](https://athemathmo.github.io/2016/03/07/rusty-machine.html).
+* [Rust testing with Stainless](http://bettong.net/2016/03/09/rust-testing-with-stainless/). Stainless is a lightweight, flexible, unopinionated testing framework.
+* [This week in Servo 54](http://blog.servo.org/2016/03/07/twis-54/). Servo is a web browser engine written in Rust.
+* [This week in Redox 12](http://www.redox-os.org/news/this-week-in-redox-12/). Redox is an operating-system written in Rust.
+* [These weeks in Amethyst 7](http://blog.amethyst.rs/2016/03/13/twia-7/). Amethyst is a data-oriented game engine written in Rust.
+
+Number: 123  Date: 2016-03-21 
+
+* [discussion] [What, in your opinion is the worst thing about Rust?](https://www.reddit.com/r/rust/comments/4b5rfi/what_in_your_opinion_is_the_worst_thing_about_rust/).
+* [The epic story of Dropbox’s exodus from the amazon cloud empire (feat. Rust)](http://www.wired.com/2016/03/epic-story-dropboxs-exodus-amazon-cloud-empire/).
+* [Servo is going to have an alpha release in June: Servo + browser.html](https://www.reddit.com/r/rust/comments/4aec34/servo_is_going_to_have_an_alpha_release_in_june/).
+* [Learn you a Rust II - references and borrowing](http://pro.theta.eu.org/2016/03/18/lyar-borrows.html).
+* [Mozilla looks towards the IoT for Rust](https://www.voxxed.com/blog/2016/03/rust/).
+* [Working with C unions in Rust FFI](http://hermanradtke.com/2016/03/17/unions-rust-ffi.html).
+* [pdf] [Fuzzing the Rust typechecker using CLP](https://www.cs.ucsb.edu/~benh/research/papers/dewey15fuzzing.pdf).
+* [This week in Servo 55](http://blog.servo.org/2016/03/14/twis-55/).
+
+Number: 124  Date: 2016-03-28 
+
+* [OneSignal now sends iOS push notifications 100x faster](https://onesignal.com/blog/announcing-our-new-delivery-backend/). Using Rust of course!
+* [String types in Rust](https://andrewbrinker.github.io/blog/2016/03/27/string-types-in-rust/). Andrew explains the difference between `String`, `str`, `OsStr`, `OsString`, `CStr`, and `CString`.
+* [Installing Rust on Windows](https://facility9.com/2016/03/installing-rust-on-windows/).
+* [Async hyper](http://seanmonstar.com/post/141495445652/async-hyper). Asynchronous IO is coming in hyper.
+* [Exploring Rust](http://nblumhardt.com/2016/03/exploring-rust/) from a C# developer's perspective.
+* [Linear Algebra written entirely in Rust](https://athemathmo.github.io/2016/03/23/linear-algebra-in-rust.html).
+* [Rust mutation testing](https://llogiq.github.io/2016/03/24/mutest.html).
+* [This week in Servo 56](http://blog.servo.org/2016/03/21/twis-56/).
+* [These weeks in Amethyst 8](https://www.amethyst.rs/_posts/twia-8.html).
+
+Number: 125  Date: 2016-04-04 
+
+* [Carol Nichols joins the Community team](https://users.rust-lang.org/t/carol-nichols-is-joining-the-community-team/5190)!
+* Steve Klabnik is giving a [2 day course introducing Rust at OSCON](http://conferences.oreilly.com/oscon/open-source-us/public/schedule/detail/49862).
+* [Call for Proposals](http://cfp.rust-belt-rust.com/) for Rust Belt Rust Conference are now open.
+* [Deploying a Rust app to Google App Engine](http://blog.jecrooks.com/posts/rust-on-appengine.html).
+* [Native JavaScript classes in Neon](http://calculist.org/blog/2016/04/01/native-js-classes-in-neon/). Neon is a safe Rust abstraction layer for native Node.js modules.
+* [Rust via its Core Values](http://designisrefactoring.com/2016/04/01/rust-via-its-core-values/). Couple of ideas about learning programming languages.
+* [Error handling in Rust](https://facility9.com/2016/03/error-handling-in-rust/).
+* [Rust borrow checker woes](http://osa1.net/posts/2016-03-28-rust-brwchk-woes.html).
+* [Linear algebra in Rust](https://bluss.github.io/rust/2016/03/28/a-gemmed-rabbit-hole/).
+* [This week in Redox 13](http://www.redox-os.org/news/this-week-in-redox-13/).
+* [This week in Servo 57](https://blog.servo.org/2016/03/28/twis-57/).
+* [Announcing the official release of the Visual C++ Build Tools 2015](https://blogs.msdn.microsoft.com/vcblog/2016/03/31/announcing-the-official-release-of-the-visual-c-build-tools-2015/). Visual C++ Build Tools are required for MSVC builds of Rust.
+
+Number: 126  Date: 2016-04-11 
+
+* [Dealing with multiple error types in Rust](https://jadpole.github.io/rust/many-error-types).
+* [Memory leaks are memory safe](https://huonw.github.io/blog/2016/04/memory-leaks-are-memory-safe/). Understanding memory safety and memory leaks.
+* [You probably meant to use `.chars().count()`](http://brandonio21.com/2016/04/rust-you-probably-meant-to-use-chars-count/). How to get the "length" of a string.
+* [Writing Varnish Cache modules (VMOD) in Rust](http://info.varnish-software.com/blog/writing-vmods-in-rust).
+* [Understanding the performance characteristics of regex crate](https://github.com/rust-lang-nursery/regex/blob/master/PERFORMANCE.md).
+* [machine learning] [Naive Bayes Classifiers in Rust](https://athemathmo.github.io/2016/04/08/naive-bayes-rusty-machine.html).
+* [This week in Servo 58](https://blog.servo.org/2016/04/04/twis-58/).
+
+Number: 127  Date: 2016-04-25 
+
+* [Writing an OS in Rust: Kernel heap](http://os.phil-opp.com/kernel-heap.html). Part of the series [Writing an OS in Rust](http://os.phil-opp.com/).
+* [Learn you a Rust III - Lifetimes 101](http://pro.theta.eu.org/2016/04/16/lyar-lifetimes.html). Part of the series [Learn you a Rust for great good!](http://pro.theta.eu.org/2016/03/12/learn-you-a-rust-for-great-good.html).
+* [PoC: using LLVM’s profile guided optimization in Rust](https://unhandledexpression.com/2016/04/14/using-llvm-pgo-in-rust/).
+* [From &str to Cow](http://blog.jwilm.io/from-str-to-cow/).
+* [The basics of Rust structs](https://facility9.com/2016/04/the-basics-of-rust-structs/).
+* [Rust community == Awesome!](https://llogiq.github.io/2016/04/23/awesome.html). How the Rust community wins despite its small size and incomplete ecosystem.
+* [This week in Rust docs 1](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-1).
+* [This week in Servo 59](http://blog.servo.org/2016/04/11/twis-59/) and [This week in Servo 60](http://blog.servo.org/2016/04/18/twis-60/).
+* [This week in Ruma 2016-04-17](https://www.ruma.io/news/this-week-in-ruma-2016-04-17/). Ruma is a Matrix client-server API written in Rust.
+
+Number: 128  Date: 2016-05-02 
+
+* [Introducing MIR](http://blog.rust-lang.org/2016/04/19/MIR.html).
+* [Myths and legends about integer overflow in Rust](https://huonw.github.io/blog/2016/04/myths-and-legends-about-integer-overflow-in-rust/).
+* [How to run Ruby inside a Rust crate](http://anima-engine.org/blog/how-to-run-ruby-inside-a-crate/).
+* [Porting a Haskell graphics framework to Rust](http://phaazon.blogspot.in/2016/04/porting-haskell-graphics-framework-to.html).
+* [Mapping over Arrays in Rust](https://llogiq.github.io/2016/04/28/arraymap.html).
+* [Optimizing matrix multiplication in Rust](http://www.suchin.co/2016/04/25/Matrix-Multiplication-In-Rust-Pt-1/).
+* [Multithreaded matrix multiplication in Rust - Part II](https://athemathmo.github.io/2016/04/25/multithreading-multiplication-2.html).
+* [Segfaults are our friends and teachers](http://kamalmarhubi.com/blog/2016/04/25/segfaults-are-our-friends-and-teachers/).
+* [This week in Redox 14](http://www.redox-os.org/news/this-week-in-redox-14/).
+* [This Week in Ruma 2016-04-24](https://www.ruma.io/news/this-week-in-ruma-2016-04-24/). Ruma is a Matrix client-server API written in Rust.
+* [The state of Rust docs](https://facility9.com/2016/04/the-state-of-rust-docs-2016/).
+
+Number: 129  Date: 2016-05-09 
+
+* [First ever RustConf will take place in Portland, US on 10 September 2016](http://rustconf.com/).
+* [Cargo: predictable dependency management](http://blog.rust-lang.org/2016/05/05/cargo-pillars.html).
+* [Non-lexical lifetimes: Introduction](http://smallcultfollowing.com/babysteps/blog/2016/04/27/non-lexical-lifetimes-introduction/).
+* [Non-lexical lifetimes based on liveness](http://smallcultfollowing.com/babysteps/blog/2016/05/04/non-lexical-lifetimes-based-on-liveness/).
+* [These weeks in Servo 61](https://blog.servo.org/2016/05/02/twis-61/).
+* [This week in Rust docs 2](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-2).
+
+Number: 130  Date: 2016-05-16 
+
+* [Introducing Helix](http://blog.skylight.io/introducing-helix/). Rust + Ruby, without the glue.
+* [Taking Rust everywhere with rustup](http://blog.rust-lang.org/2016/05/13/rustup.html). Push-button cross-compilation with rustup.
+* [Non-lexical lifetimes: Adding the outlives relation](http://smallcultfollowing.com/babysteps/blog/2016/05/09/non-lexical-lifetimes-adding-the-outlives-relation/).
+* [Deep Learning in Rust: a walk in the park](https://medium.com/@tedsta/deep-learning-in-rust-a-walk-in-the-park-fed6c87165ea)
+* [Rust for Node.js developers - Part 1 - Introduction to Rust](http://fredrik.anderzon.se/2016/05/10/rust-for-node-developers-part-1-introduction/).
+* [Writing documentation in Rust](https://facility9.com/2016/05/writing-documentation-in-rust/).
+* [Fancy Rust development with Emacs](http://julienblanchard.com/2016/fancy-rust-development-with-emacs/).
+* [Quick check: does your code work?](https://fnordig.de/2016/05/12/quickcheck-does-your-code-work/) Using QuickCheck to do property based testing.
+* [Autoconf for Rust projects](http://aravindavk.in/blog/autoconf-for-rust-projects/).
+* [This week in Servo 62](https://blog.servo.org/2016/05/09/twis-62/).
+* [This week in Rust docs 3](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-3).
+* [This week in intermezzOS 1](https://intermezzos.github.io/blog/articles/twii1/). intermezzOS is a learning operating system with a companion book, written in Rust.
+* [video] [Ferris makes emulators: Episode 8](https://www.youtube.com/watch?v=ToOt-osLxNk). Live stream of Ferris developing a N64 emulator in Rust (also on [Twitch](http://www.twitch.tv/ferrisstreamsstuff/profile)).
+
+Number: 131  Date: 2016-05-23 
+
+* [Let's build a web server in Rust](https://dfockler.github.io/2016/05/20/web-server.html).
+* [Creating a basic webservice in Rust](http://hermanradtke.com/2016/05/16/creating-a-basic-webservice-in-rust.html).
+* [Writing GStreamer plugins and elements in Rust](https://coaxion.net/blog/2016/05/writing-gstreamer-plugins-and-elements-in-rust/).
+* [Writing a compiler plugin to instrument code](https://llogiq.github.io/2016/05/17/flamer.html).
+* [Our polyglot approach: Getting started with Rust](https://tech.zalando.de/blog/getting-started-with-rust/).
+* [This week in Rust docs 4](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-4).
+* [This week in Parity 1](https://ethcore.github.io/twip/2016-05-17.html).
+* [This week in RustFest 1: Introduction](http://www.rustfest.eu/blog/this-week-in-rustfest-1).
+* [This week in Ruma 2016-05-22](https://www.ruma.io/news/this-week-in-ruma-2016-05-22/).
+* [Plushie Rustacean pattern](http://edunham.net/2016/04/11/plushie_rustacean_pattern.html). Sew your own plush Rustacean toy!
+
+Number: 132  Date: 2016-05-30 
+
+* [The Path to Rust](https://thesquareplanet.com/blog/the-path-to-rust/). Why Rust might be right for you.
+* [How do I convert a `&str` to a `String` in Rust](https://mgattozzi.github.io/2016/05/26/how-do-i-str-string.html)? A series of "How do I do X in Rust?" articles aimed at beginners.
+* [Catching Exceptions](http://os.phil-opp.com/catching-exceptions.html). Part of the series [Writing an OS in Rust](http://os.phil-opp.com/).
+* [Connecting a webservice to a database in Rust](http://hermanradtke.com/2016/05/23/connecting-webservice-database-rust.html).
+* [Unsafe abstractions](http://smallcultfollowing.com/babysteps/blog/2016/05/23/unsafe-abstractions/). Understanding `unsafe` code and the idea of unsafety boundaries.
+* [The 'Tootsie Pop' model for unsafe code](http://smallcultfollowing.com/babysteps/blog/2016/05/27/the-tootsie-pop-model-for-unsafe-code/). Niko Matsakis outlines a high-level approach to defining a memory model. Follow-up to "Unsafe abstractions".
+* [Async generators](https://dwrensha.github.io/capnproto-rust/2016/05/28/async-generators.html). Making a case for generators based async I/O in Rust.
+* [Using Wayland from Rust, Part 2](http://blog.levans.fr/rust_wayland_2-en.html).
+* [Using Rust 1.8 stable for building embedded firmware](https://spin.atomicobject.com/2016/05/25/rust-1-8-embedded-firmware/).
+* [Attempting to use Rust's type system for statically checked dependency tracking](https://michaelwoerister.github.io/2016/05/28/attempting-to-use-rusts-type-system-for-statically-check-dependency-tracking.html).
+* [This week in Servo 64](https://blog.servo.org/2016/05/23/twis-64/).
+* [This week in Rust docs 5](https://www.reddit.com/r/rust/comments/4kqlsk/this_week_in_rust_docs_5/).
+* [This week in Parity 2](https://ethcore.github.io/twip/content/2016-05-25.html).
+* [This week in Ruma 2016-06-29](https://www.ruma.io/news/this-week-in-ruma-2016-05-29/).
+* [podcast] [Rust with Steve Klabnik](http://softwareengineeringdaily.com/2016/05/24/rust-steve-klabnik/).
+* [The Rust community](http://www.suspectsemantics.com/blog/2016/05/28/the-rust-community/). What it gets right and what it gets wrong.
+
+Number: 133  Date: 2016-06-06 
+
+* [Why is a Rust executable large](https://lifthrasiir.github.io/rustlog/why-is-a-rust-executable-large.html)?
+* [`&` vs. `ref` in Rust patterns](http://xion.io/post/code/rust-patterns-ref.html).
+* [How do I use the Standard Library Macros in Rust? Part 1](https://mgattozzi.github.io/2016/06/01/how-do-i-std-macros.html).
+* [Things you could do with the Rust AST](http://kamalmarhubi.com/blog/2016/06/02/playing-with-the-rust-ast/).
+* [Beyond memory safety with types](https://insanitybit.github.io/2016/05/30/beyond-memory-safety-with-types).
+* [Interfacing Rust with the JVM](https://github.com/mottalli/rust-jni-test).
+* [Tween: a middleware library experiment](https://chrismorgan.info/blog/tween.html).
+* [podcast] [New Rustacean: News episode 01](http://www.newrustacean.com/show_notes/news/_1/). A year in, Rust is changing fast but still stable.
+* [video] [Ferris makes emulators: Episode 11 - Debugger part 2](https://www.youtube.com/watch?v=chU5uWs1sLw). Live stream of Ferris developing a N64 emulator in Rust (also on [Twitch](http://www.twitch.tv/ferrisstreamsstuff/profile)).
+
+Number: 134  Date: 2016-06-13 
+
+* [Baby steps: Slowly porting musl to Rust](http://blog.adamperry.me/rust/2016/06/11/baby-steps-porting-musl-to-rust/).
+* [Why Rust for Low-level Linux programming](http://groveronline.com/2016/06/why-rust-for-low-level-linux-programming/)?
+* [Lambda crabs (part 1): A mathematical introduction to lifetimes and regions](https://ticki.github.io/blog/lambda_crabs_1/).
+* [Lambda crabs (part 2): Region inference is (not) magic](https://ticki.github.io/blog/lambda_crabs_2/).
+* [Lambda crabs (part 3): Region-based alias analysis](https://ticki.github.io/blog/lambda_crabs_3/).
+* [Interior mutability in Rust: what, why, how](https://ricardomartins.cc/2016/06/08/interior-mutability)?
+* [Heterogeneous linked lists in Rust](http://src.codes/typed-linked-lists.html).
+* [Procedural macros vs. macros](https://llogiq.github.io/2016/06/11/expand.html).
+* [Beware upcoming Dyon v0.8 - It will be awesome](http://blog.piston.rs/2016/06/07/beware-dyon/)! Dyon is a dynamically typed programming language written in Rust.
+* [Sandboxing code in Rust](https://insanitybit.github.io/2016/06/11/sandboxing-code-in-rust).
+* [Recordings & slides from Rust Anniversary – Part II meetup](http://rustaceans.cologne/2016/06/06/rust-anniversary-part-2.html). Featuring [alexcrichton](https://github.com/alexcrichton), [llogiq](https://github.com/llogiq), and [flanfly](https://github.com/flanfly).
+* [Rust out your C](https://github.com/carols10cents/rust-out-your-c-talk). [Carol](https://github.com/carols10cents) talks about her experience in rewriting [Zopfli](https://github.com/google/zopfli) from C to Rust.
+
+Number: 135  Date: 2016-06-20 
+
+* [Writing a simple REST app in Rust](https://gsquire.github.io/static/post/rest-in-rust/).
+* [Paradigms of Rust for the Go developer](https://medium.com/@deckarep/paradigms-of-rust-for-the-go-developer-210f67cd6a29#.6rw2gwmg1).
+* [Using ltrace to debug a memory leak](http://jvns.ca/blog/2016/06/15/using-ltrace-to-debug-a-memory-leak/).
+* [Scheduling timers on OS X with Rust and Kqueue](http://nitschinger.at/Scheduling-Timers-on-OS-X-with-Rust-and-Kqueue/).
+* [Problem in Rust adoption](https://sanxiyn.blogspot.in/2016/06/problem-in-rust-adoption.html).
+* [podcast] [New Rustacean podcast episode 15](http://www.newrustacean.com/show_notes/e015/index.html). `Box`, `String`, `Vec`, `Rc`, and `Arc` have this in common: they're not dumb.
+
+Number: 136  Date: 2016-06-27 
+
+* [Mozilla awards MIO $30k as part of MOSS program](https://blog.mozilla.org/blog/2016/06/22/mozilla-awards-385000-to-open-source-projects-as-part-of-moss-mission-partners-program/).
+* [Rust for Node developers](https://github.com/Mercateo/rust-for-node-developers). An introduction to the Rust programming language for Node developers.
+* [Using Gaussian Mixture Models in Rust](https://athemathmo.github.io/2016/06/24/using-gmm-in-rust.html).
+* [Interior mutability in Rust, part 2: thread safety](https://ricardomartins.cc/2016/06/25/interior-mutability-thread-safety).
+* [Shipping forgettable microservices with Rust](https://precompile.com/2016/06/23/shipping-forgettable-microservices-with-rust.html).
+* [Rust for Node.js developers - Part 2 - Can I borrow that](http://fredrik.anderzon.se/2016/06/17/rust-for-node-js-developers-part-2-can-i-borrow-that/)?
+* [podcast] [New Rustacean interview 2](http://www.newrustacean.com/show_notes/interview/_2/part_1/index.html). Raph Levien on using Rust to build the Xi editor.
+
+Number: 137  Date: 2016-07-05 
+
+* [State of Rust survey 2016](http://blog.rust-lang.org/2016/06/30/State-of-Rust-Survey-2016.html).
+* [rust-brotli: Lossless compression with Brotli in Rust](https://blogs.dropbox.com/tech/2016/06/lossless-compression-with-brotli/).
+* [A toy front-end for LLVM, written in Rust](http://blog.ulysse.io/2016/07/03/llvm-getting-started.html).
+* [First steps in Rust](https://floooh.github.io/2016/06/27/first-steps-in-rust.html). Early impressions of Rust from the perspective of a C, C++ and Python coder.
+* [Attention! Span](https://llogiq.github.io/2016/06/28/span.html). Llogiq on `syntax::codemap::Span`, Rust's interface between macros and lints.
+* [Implementing an IMAP client in Rust](https://insanitybit.github.io/2016/06/28/implementing-an-imap-client-in-rust).
+* [podcast] [New Rustacean interview](http://www.newrustacean.com/show_notes/interview/_2/part_2/). Raph Levien on Rust's current strengths and places it can improve.
+* [video] [Shar Bringer](https://www.youtube.com/watch?v=40DGf1eKb_Y). Demo of a video game written entirely in Rust. ([Discussion thread](https://www.reddit.com/r/rust_gamedev/comments/4qlftu/look_our_game_writen_entirely_in_rust/)).
+
+Number: 138  Date: 2016-07-12 
+
+* [Refining Rust's RFCs](https://aturon.github.io/blog/2016/07/05/rfc-refinement/).
+* [Translating C to Rust using Corrode (and how you can help)](http://jamey.thesharps.us/2016/07/translating-c-to-rust-and-how-you-can.html).
+* [Rust and Rest](http://lucumr.pocoo.org/2016/7/10/rust-rest/). Lessons Learned from talking to Sentry's HTTP API from Rust.
+* [Pairing cryptography in Rust](https://z.cash/blog/pairing-cryptography-in-rust.html).
+* [Shave some time from your Travis builds](https://llogiq.github.io/2016/07/05/travis.html).
+* [Overview of open source game engines in Rust](http://www.shadercat.com/overview-of-open-source-game-engines-in-rust/).
+* [Rust & Docker in production @ Coursera](https://building.coursera.org/blog/2016/07/07/rust-docker-in-production-coursera/).
+* [Integer 32](http://www.integer32.com/), a Rust consultancy startup by [Carol Nichols](https://github.com/carols10cents) and [Jake Goulding](https://github.com/shepmaster).
+
+Number: 139  Date: 2016-07-19 
+
+* [Mozilla is shipping its first production Rust code in Firefox 48](https://hacks.mozilla.org/2016/07/shipping-rust-in-firefox/).
+* [Linux perf gets Rust symbol demangling support](https://git.kernel.org/cgit/linux/kernel/git/tip/tip.git/commit/?id=cae15db74999edb96dd9f5bbd4d55849391dd92b).
+* [Testing strategies for Corrode](http://jamey.thesharps.us/2016/07/testing-strategies-for-corrode.html). Corrode is a C to Rust translator.
+* [Rust for Node.js developers - Part 3](http://fredrik.anderzon.se/rust-for-node-js-developers-part-3-crates-modules-and-the-web/). Crates, Modules and the web.
+* [How to package Rust applications to RPM using vendoring](https://czanik.blogs.balabit.com/2016/07/how-to-package-rust-applications-to-rpm-using-vendoring/).
+* [A Rust-powered public web page in 5 minutes](https://medium.com/@rap2h/a-rust-powered-public-website-in-5-minutes-b682d8527b6b).
+
+Number: 140  Date: 2016-07-26 
+
+- [The 2016 Rust conference lineup](https://blog.rust-lang.org/2016/07/25/conf-lineup.html).
+- [Rust performance: A story featuring perf and flamegraph on Linux](http://blog.adamperry.me/rust/2016/07/24/profiling-rust-perf-flamegraph/).
+- [Sebastian Ullrich has formally verified Rust's binary_search
+  function by transpiling Rust to the Lean theorem
+  prover](https://kha.github.io/2016/07/22/formally-verifying-rusts-binary-search.html).
+- [A short walkthrough of WebRender 2](http://www.masonchang.com/blog/2016/7/18/a-short-walkthrough-of-webrender-2).
+- [Rust code coverage guide](http://sunjay.ca/2016/07/25/rust-code-coverage). kcov + Travis CI + Codecov / Coveralls.
+- [Rust: The new LLVM](http://notes.willcrichton.net/rust-the-new-llvm/). Making a case for using Rust as compile target for new languages.
+- [Test setup and teardown in Rust without a framework](https://medium.com/@ericdreichert/test-setup-and-teardown-in-rust-without-a-framework-ba32d97aa5ab).
+- [podcast] [New Rustacean podcast episode 16](http://www.newrustacean.com/show_notes/e016/). Digging deeper on smart pointers and mutability with `Cell` and `RefCell`.
+
+Number: 141  Date: 2016-08-02 
+
+* [Huon Wilson and Alexis Beingessner become Rust Team Alumni](https://internals.rust-lang.org/t/rust-team-alumni/3784).
+* [The Internet on Redox](https://www.redox-os.org/news/the-internet-on-redox/). Current state of the Redox operating system. Spoiler: It's progressing fast!
+* [Inside the fastest font renderer in the world](https://medium.com/@raphlinus/inside-the-fastest-font-renderer-in-the-world-75ae5270c445). font-rs, a font renderer written in Rust is an order of magnitude faster than the industry-standard FreeType.
+* [The Rust Platform](https://aturon.github.io/blog/2016/07/27/rust-platform/). Aaron Turon on the concept of “Rust Platform Package”, a _batteries included_ Rust development experience.
+* [Follow up on The Rust Platform](https://internals.rust-lang.org/t/follow-up-the-rust-platform/3782) by Aaron Turon.
+* [Hidden treasures of the Rust ecosystem](https://scribbles.pascalhertleif.de/hidden-treasures-of-the-rust-ecosystems.html).
+* [Structure literals vs constructors in Rust](http://words.steveklabnik.com/structure-literals-vs-constructors-in-rust).
+* [for loops in Rust](http://xion.io/post/code/rust-for-loop.html).
+* [Rust: Beyond the basics](https://medium.com/learning-rust/rust-beyond-the-basics-4fc697e3bf4f).
+* [References and UnsafeCell](https://ubsan.github.io/References-And-UnsafeCell/). Understanding references (`&T` and `&mut T`) and `UnsafeCell`.
+* [Hello World MesssageBox example in Rust](https://wesleywiser.github.io/post/rust-windows-messagebox-hello-world/). Developing a simple GUI application for Windows.
+* [Another happy quickcheck customer](https://llogiq.github.io/2016/07/29/quickcheck.html). @llogiq on his experience with QuickCheck. QuickCheck is a way to do property based testing using randomly generated input.
+
+Number: 142  Date: 2016-08-09 
+
+* [Announcing Tokio](https://medium.com/@carllerche/announcing-tokio-df6bb4ddb34). A Finagle inspired network application framework for Rust.
+* [Helping with the Rust errors](http://www.jonathanturner.org/2016/08/helping-out-with-rust-errors.html). Step-by-step instructions on how to help with the new Rust error messages.
+* [Introduction to nom](http://hermanradtke.com/2016/08/08/introduction-to-nom-rust-parsing-combinator-framework.html). A parsing framework written in Rust.
+* [Convenient and idiomatic conversions in Rust](https://ricardomartins.cc/2016/08/03/convenient_and_idiomatic_conversions_in_rust).
+* [Better Exception Messages](http://os.phil-opp.com/better-exception-messages.html). Part of the series [Writing an OS in Rust](http://os.phil-opp.com/).
+* [Writing a JPEG decoder in Rust](https://mht.technology/post/jpeg-rust-1/). Part 1: Background.
+* [Extent of Intent](https://llogiq.github.io/2016/08/05/intent.html). Llogiq considers no-ops for consistency's sake harmful.
+* [Rust code in mozilla-central now builds via cargo](https://groups.google.com/forum/#!topic/mozilla.dev.platform/BVPBhexRN3s).
+* [imag usecases](http://beyermatthias.de/blog/2016/08/07/imag-usecases/). imag usecases explained.
+* [podcast] [New Rustacean podcast episode 17](http://www.newrustacean.com/show_notes/e017/). A deep dive on references and pointers in Rust.
+
+Number: 143  Date: 2016-08-16 
+
+- [Security Advisory for crates.io, 2016-08-15](https://users.rust-lang.org/t/security-advisory-for-crates-io-2016-08-15/6907). Please read, especially if you've renamed your GitHub account.
+- [Shape of errors to come](https://blog.rust-lang.org/2016/08/10/Shape-of-errors-to-come.html). A sneak peek at new & improved error formats in Rust.
+- [What’s new with “The Rust Programming Language”](http://words.steveklabnik.com/whats-new-with-the-rust-programming-language)? Second edition of TRPL book is coming up with [Carol (Nichols || Goulding)](https://github.com/carols10cents) as a co-author.
+- [Zero-cost futures in Rust](https://aturon.github.io/blog/2016/08/11/futures/). futures-rs is now ready for prime time!
+- [Futures in Rust](http://www.ishbir.com/post/2016-08-14-futures-in-rust/). Writing an Async Web API Wrapper - An excercise in learning Rust.
+- [Rust compiler walk-through: Introduction](https://gchp.ie/2016/08/09/rust-compiler-walkthrough-introduction/).
+- [Asynchronous servers in Rust](https://gkbrk.com/2016/08/asynchronous-servers-in-rust/). Using tokio-rs to build an asynchronous server.
+- [Parsing strategies in Rust](http://notes.willcrichton.net/parsing-strategies-in-rust/). Comparing two competing parsing frameworks in Rust: nom, a parser combinator, and LALRPOP, an LR(1) parser generator.
+- [Xero and Sandstorm.io have been added to the Friends of Rust page](https://www.rust-lang.org/en-US/friends.html). Xero is using Rust for infrastructure, and Sandstorm.io has a [collections application](https://sandstorm.io/news/2016-08-09-collections-app) in Rust.
+
+Number: 144  Date: 2016-08-23 
+
+* [A year of Rust and DNS](https://bluejekyll.github.io/blog/rust/dns/2016/08/21/a-year-of-rust-and-dns.html). Benjamin Fry talks about his experience developing [trust-dns
+](https://github.com/bluejekyll/trust-dns) - a Rust based DNS server.
+* [GC support in Rust: API design](https://manishearth.github.io/blog/2016/08/18/gc-support-in-rust-api-design/).
+* [Writing a JPEG decoder in Rust - Part 2: Implementation I](https://mht.technology/post/jpeg-rust-2/).
+* [A Tokio echo server in 35 lines](https://pyfisch.org/blog/tokio-echo-server/). Tokio is a network application framework for Rust.
+* [Filters everywhere](http://beyermatthias.de/blog/2016/08/22/filters-everywhere/). Short intro to the "filters" crate and remaining issues.
+* [<img alt="fire" class="emoji" title=":fire:" src="https://cdn.discourse.org/business/images/emoji/emoji_one/fire.png?v=0"> discussion] [The `?` operator will be harmful to Rust](https://internals.rust-lang.org/t/the-operator-will-be-harmful-to-rust/3882).
+* [slides] [Rust: Systems programming for everyone](https://pnkfelix.github.io/presentations/qcon-london2016-deploy/qcon-london2016.html).
+* [podcast] [New Rustacean bonus episode 6](http://www.newrustacean.com/show_notes/bonus/_6/). Building (and celebrating) all the little, not-so-glorious pieces of the Rust ecosystem.
+
+Number: 145  Date: 2016-08-30 
+
+* [Expanding the Tokio project](https://aturon.github.io/blog/2016/08/26/tokio/). Announcing the formation of the Tokio Core Team, as well as an overall plan for the two projects (Tokio & Futures) and how they fit together.
+* [Moving, cloning, and copying coloring books in Rust](http://jeenalee.com/2016/08/29/move-clone-copy.html).
+* [Optimizing Threshold Secret Sharing](https://medium.com/snips-ai/optimizing-threshold-secret-sharing-c877901231e5). Playing with Fourier transform in Rust.
+* [Running rustfmt on Travis CI](http://johannh.me/blog/rustfmt-ci.html).
+* [Chomp and impl Trait, revisited](https://m4rw3r.github.io/chomp-impl-trait--revisited).
+* [nRF51 support for Tock Operating System](http://www.tockos.org/blog/2016/nrf51-support/).
+* [In-place transposition in Rust](https://athemathmo.github.io/2016/08/29/inplace-transpose.html). Getting an optimized in-place transposition algorithm working in [rulinalg](https://github.com/AtheMathmo/rulinalg) - a pure Rust linear algebra library.
+* [Rustdoc meets the self-documenting editor](http://www.wilfred.me.uk/blog/2016/08/27/rustdoc-meets-the-self-documenting-editor/). racer.el for Emacs can now render rustdoc comments.
+* [An unmatched left parenthesis...](https://llogiq.github.io/2016/08/25/delim.html). Should error messages take code indentation into account for better reporting?
+* ['StoreId' - The biggest imag design flaw by now](http://beyermatthias.de/blog/2016/08/24/-storeid-the-biggest-imag-design-flaw-by-now/).
+
+Number: 146  Date: 2016-09-06 
+
+* [Rust's vision for the 2017 cycle](https://internals.rust-lang.org/t/setting-our-vision-for-the-2017-cycle/3958).
+* [One year of Rust](https://mgattozzi.github.io/2016/08/30/1-year-of-rust.html). How Rust and its community has changed in last one year and what we as a community can do differently.
+* [The next version of Fedora picks up Rust](http://www.infoworld.com/article/3114475/open-source-tools/the-next-version-of-fedora-picks-up-rust.html).
+* [Thoughts on conducting a beginner level Rust workshop](http://pramode.in/2016/09/05/on-teaching-rust-to-beginners/).
+* [Wasted](https://llogiq.github.io/2016/08/30/wasted.html). [@llogiq](https://github.com/llogiq) has ideas on reducing network bandwidth when using rustup & Cargo.
+* [Porting cargo benchcmp from Python to Rust](https://apanatshka.github.io/compsci/2016/09/04/porting-cargo-benchcmp/).
+* [Porting a Raspberry Pi GPIO programming library from Python to Rust](http://pramode.in/2016/08/31/rust-library-for-rpi-gpio-pgming/).
+* [Rust merge process for new contributors](https://blog.guillaume-gomez.fr/articles/2016-08-31+Rust+merge+process).
+
+Number: 147  Date: 2016-09-13 
+
+* [Understanding incremental compilation](https://blog.rust-lang.org/2016/09/08/incremental.html). Now available in Rust nightly.
+* [Higher-rank and higher-kinded types](https://www.stephanboyer.com/post/115/higher-rank-and-higher-kinded-types) explained using a Java-like syntax.
+* [Designing Futures for Rust](https://aturon.github.io/blog/2016/09/07/futures-design/). Explaining the core design of Futures library.
+* [The relationship between async libraries in Rust](https://www.jimmycuadra.com/posts/the-relationship-between-async-libraries-in-rust/). How Futures, MIO, and Tokio are different from each other.
+* [Thoughts on trusting types and unsafe code](http://smallcultfollowing.com/babysteps/blog/2016/09/12/thoughts-on-trusting-types-and-unsafe-code/) - by Niko Matsakis.
+* [Learning systems programming with Rust](http://jvns.ca/blog/2016/09/11/rustconf-keynote/). Transcript of the closing keynote at the first RustConf.
+* [Writing GStreamer elements in Rust (Part 2)](https://coaxion.net/blog/2016/09/writing-gstreamer-elements-in-rust-part-2-dont-panic-we-have-better-assertions-now-and-other-updates/). Read part 1 [here](https://coaxion.net/blog/2016/05/writing-gstreamer-plugins-and-elements-in-rust/).
+* [A critique of Rust's `std::collections`](https://ticki.github.io/blog/horrible/).
+* [Why I’m dropping Rust](https://medium.com/@kingoipo/why-im-dropping-rust-fd1c32986c88). (See this [reddit discussion thread](https://www.reddit.com/r/rust/comments/5295nf/why_im_dropping_rust/) for responses from the Rust community).
+* [podcast] [New Rustacean bonus episode 7](http://www.newrustacean.com/show_notes/bonus/_7/). Building (and celebrating) all the little, not-so-glorious pieces of the Rust ecosystem.
+
+Number: 148  Date: 2016-09-20 
+
+* [My experience rewriting Enjarify in Rust](https://medium.com/@robertgrosse/my-experience-rewriting-enjarify-in-rust-723089b406ad). Enjarify is a tool (written in Python) for translating Dalvik bytecode to equivalent Java bytecode.
+* [The PlayRust Classifier](http://www.suchin.co/2016/09/13/The-PlayRust-Classifier/). Synopsis of a RustConf talk on a classifier to detect posts that were intended for [/r/playrust](https://www.reddit.com/r/playrust/) but were mistakenly posted on [/r/rust](https://www.reddit.com/r/rust/).
+* [Why Rust's `std::collections` is absolutely fantastic](https://ticki.github.io/blog/fantastic/). Follow-up to - [a critique of Rust's `std::collections`](https://ticki.github.io/blog/horrible/).
+* [Using `and_then` and `map` combinators on the Rust `Result` Type](http://hermanradtke.com/2016/09/12/rust-using-and_then-and-map-combinators-on-result-type.html).
+* [GFX Programming Model](http://gfx-rs.github.io/2016/09/14/programming-model.html). A deep dive into what makes gfx-rs complex and awesome.
+* [Building a scalable MySQL Proxy in Rust](http://www.agildata.com/building-scalable-mysql-proxy-rust/).
+* [Using unsafe tricks to examine Rust data structure layout](http://pramode.in/2016/09/13/using-unsafe-tricks-in-rust/).
+* [Tools for profiling Rust](https://athemathmo.github.io/2016/09/14/tools-for-profiling-rust.html).
+* [Generating Rustdoc with a custom style](https://blog.guillaume-gomez.fr/articles/2016-09-16+Generating+doc+with+rustdoc+and+a+custom+theme).
+* [Understanding where clauses and trait constraints](https://mgattozzi.github.io/2016/09/13/understanding-where-clauses.html).
+* [Let's Build a REPL/Parser with Rust & LALRPOP](https://dfockler.github.io/2016/09/15/lalrpop.html).
+* [video] [Videos from Rust Meetup Cologne/Bonn](https://media.ccc.de/c/rustmcb).
+### RustConf Experiences
+* [My RustConf travelogue](http://zackmdavis.net/blog/2016/09/rustconf-2016-travelogue/) by Zack M. Davis.
+* [Rustconf 2016 – What was cool and what surprised me](http://www.agildata.com/rustconf-2016-what-was-cool-and-what-surprised-me/) by Andy Grove.
+* [Notes from RustConf 2016 talks](http://alwayscoding.ca/momentos/2016/09/10/rustconf-2016-talks/) by Brian Pearce.
+
+Number: 149  Date: 2016-09-27 
+
+* [Returning from Exceptions](http://os.phil-opp.com/returning-from-exceptions.html). How to return from exceptions correctly. Part of the series [Writing an OS in Rust](http://os.phil-opp.com/).
+* [ripgrep is faster than {grep, ag, git grep, ucg, pt, sift}](http://blog.burntsushi.net/ripgrep/). ripgrep is a command line search tool that combines the usability of The Silver Searcher (an ack clone) with the raw speed of GNU grep.
+* [Intersection Impls](http://smallcultfollowing.com/babysteps/blog/2016/09/24/intersection-impls/). A specialization example of adding a blanket impl that implements `Clone` for any `Copy` type, its shortcomings, and one proposed fix using intersection impls (also called lattice impls).
+* [My adventures in Rust web development](https://medium.com/@tomaka/my-adventures-in-rust-webdev-850c67be6c40).
+* [From tweet to Rust feature](https://llogiq.github.io/2016/09/14/feature.html). Journey of an idea from being a tweet to becoming a Rust feature.
+* [How to count newlines really fast in Rust](https://llogiq.github.io/2016/09/24/newline.html).
+* [Writing Cocoa apps in Rust](https://kylewlacy.github.io/posts/cocoa-apps-in-rust-eventually/).
+* [Experiment: compare ZODB file-storage iteration with Python and Rust](http://jimfulton.info/site/2016/Sep/25/experiment-compare-zodb-file-storage-iteration-with-python-and-rust/).
+* [Implementing Huffman coding in Rust](http://pramode.in/2016/09/26/huffman-coding-in-rust/).
+### RustConf/RustFest Experiences
+* [My Thoughts on RustConf 2016](http://jeenalee.com/2016/09/23/rust-conf.html) by Jeena Lee.
+* [RustConf and Strange Loop 2016](http://hellomalisa.me/2016-09-20/rustconf-and-strange-loop.html) by Malisa.
+* [Habitat at RustConf](https://blog.chef.io/2016/09/23/habitat-at-rustconf/) by Salim Alam.
+* [RustFest was great!](https://blog.cyplo.net/posts/2016/09/rustfest-organization-was-the-best.html) by Cyryl Płotnicki.
+
+Number: 150  Date: 2016-10-04 
+
+* [Ethereum users are recommended to switch to Parity (an Ethereum client written in Rust) to mitigate ongoing DoS attack](https://blog.ethereum.org/2016/09/22/ethereum-network-currently-undergoing-dos-attack/). Further reads - [out of memory bug in Geth client](https://blog.ethereum.org/2016/09/18/security-alert-geth-nodes-crash-due-memory-bug/) and [next steps against transaction spam attack](https://blog.ethereum.org/2016/09/22/transaction-spam-attack-next-steps/).
+* [Optional arguments in Rust 1.12](http://xion.io/post/code/rust-optional-args.html).
+* [Applying Hoare logic to the Rust MIR](https://ticki.github.io/blog/a-hoare-logic-for-rust/). Hoare logic is a formal system with a set of logical rules for reasoning rigorously about the correctness of computer programs (from [Wikipedia article](https://en.wikipedia.org/wiki/Hoare_logic)).
+* [Rust as a language for high performance GC implementation](http://ts.data61.csiro.au/publications/nictaabstracts/Lin_BHN_16.abstract.pml).
+* [How to use Rust code inside Haskell](https://mgattozzi.github.io/2016/10/01/haskell-rust.html).
+* [Rusty dynamic loading](https://damienradtke.com/post/rusty-dynamic-loading/). How to utilize dynamic libraries to reload code on the fly.
+* [Safe and efficient bidirectional trees](https://www.reddit.com/r/rust/comments/55ns2m/safe_and_efficient_bidirectional_trees/).
+* [How to implement a new DOM API for Servo](http://jeenalee.com/2016/10/03/implementing-doge-for-servo.html).
+* [Observational equivalence and unsafe code](http://smallcultfollowing.com/babysteps/blog/2016/10/02/observational-equivalence-and-unsafe-code/). Observational equivalence is the property of two or more underlying entities being indistinguishable on the basis of their observable implications (from [Wikipedia article](https://en.wikipedia.org/wiki/Observational_equivalence)).
+* [Distinguishing reuse from override](http://smallcultfollowing.com/babysteps/blog/2016/09/29/distinguishing-reuse-from-override/). Follow-up to last week's [intersection impls](http://smallcultfollowing.com/babysteps/blog/2016/09/24/intersection-impls/) article.
+* [Even quicker byte count](https://llogiq.github.io/2016/09/27/count.html). Follow-up to last week's [how to count newlines really fast in Rust](https://llogiq.github.io/2016/09/24/newline.html).
+* [Implementing Finite Automata in Rust (Part 1)](https://apanatshka.github.io/compsci/2016/10/03/implementing-finite-automata-part-1/).
+* [Building personalized IPC debugging tools using Electron and Rust](https://wraithan.net/2016/10/02/i-can-manage-it-weekly-update-3/).
+* [Easier Rust Development on the PJRC Teensy 3](http://jamesmunns.com/update/2016/09/26/teensy3-rs.html). PJRC Teensy is a USB-based microcontroller development system.
+* [Why you should be blogging about Rust](https://mgattozzi.github.io/2016/09/27/blog-about-rust.html).
+
+Number: 151  Date: 2016-10-11 
+
+* [GDB 7.12 is released with Rust debugging support](https://www.mail-archive.com/info-gnu@gnu.org/msg02192.html).
+* [CodeLLDB: a LLDB front end for Visual Studio Code - now supports Rust debugging](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb).
+* [Diesel 0.8.0 is released with diesel_codegen rewritten to use the Macros 1.1 framework](https://github.com/diesel-rs/diesel/commit/04bf2fcbc7f756d577e85afe00c8a133f9b84d4b).
+* [rustup is now available in `Community` repo of Arch Linux](https://www.archlinux.org/packages/community/x86_64/rustup/).
+* [Macros (and syntax extensions and compiler plugins) - where are we at](https://users.rust-lang.org/t/macros-and-syntax-extensions-and-compiler-plugins-where-are-we-at/7600)?
+* [imag pre-1.0.0 release strategy](http://beyermatthias.de/blog/2016/10/04/imag-pre-1-0-0-release-strategy/).
+## Other Weeklies from Rust Community
+* [This week in Servo 80](https://blog.servo.org/2016/10/03/twis-80/). Servo is a prototype web browser engine written in Rust.
+* [This week in Rust docs 25](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-25). Updates from the Rust documentation team.
+* [This week in Ruma 2016-10-09](https://www.ruma.io/news/this-week-in-ruma-2016-10-09/). Ruma is a Matrix homeserver written in Rust.
+* [This week in Tock OS 6](http://www.tockos.org/blog/2016/talking-tock-6/). Tock is a safe, multitasking operating system for low-power, low-memory microcontrollers.
+* [This week in Ruru 2](http://this-week-in-ruru.org/2016/10/04/this-weeks-in-ruru-2/). Ruru lets you write native Ruby extensions in Rust.
+* [What's coming up in imag (17)](http://beyermatthias.de/blog/2016/10/07/what-s-coming-up-in-imag-17/). imag is a text based personal information management suite.
+
+Number: 153  Date: 2016-10-25 
+
+* [Introducing Rust Language Server, source release](https://internals.rust-lang.org/t/introducing-rust-language-server-source-release/4209). RLS provides a service that runs in the background, providing IDEs, editors, and other tools with information about Rust programs.
+* [Facebook is writing a Mercurial server in Rust](https://groups.google.com/forum/#!topic/mozilla.dev.version-control/nh4fITFlEMk).
+* [Announcing Cage: Develop and deploy complex Docker applications](http://blog.faraday.io/announcing-cage-develop-and-deploy-complex-docker-applications/).
+* [imag v0.2.0 released](http://beyermatthias.de/blog/2016/10/23/imag-0-2-0/).
+## Other Weeklies from Rust Community
+* [This summer in Redox](https://www.redox-os.org/news/this-summer-in-redox-15/). Redox is an operating-system written in Rust.
+* [These weeks In Servo 81](https://blog.servo.org/2016/10/17/twis-81/). Servo is a prototype web browser engine written in Rust.
+* [This week in Rust Docs 27](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-27). Updates from the Rust documentation team.
+* [This week in Tock Embedded OS #7](http://www.tockos.org/blog/2016/talking-tock-7/). Tock is a safe, multitasking operating system for low-power, low-memory microcontrollers.
+* [This week in Ruru 3](http://this-week-in-ruru.org/2016/10/24/this-weeks-in-ruru-3/). Ruru lets you write native Ruby extensions in Rust.
+* [This week in TiKV 2016-10-23](http://weekly.pingcap.com/2016/10/24/tidb-weekly/#notable-changes-to-tikv). TiKV is a distributed Key-Value database.
+* [What's coming up in imag 18](http://beyermatthias.de/blog/2016/10/21/what-s-coming-up-in-imag-18/). imag is a text based personal information management suite.
+# New Crates
+* [EdgeDNS](https://github.com/jedisct1/edgedns). A high performance DNS cache designed for Content Delivery Networks, with built-in security mechanisms to protect origins, clients and itself.
+* [Pinky](https://github.com/koute/pinky). An NES emulator written in Rust.
+* [combine](https://github.com/Marwes/combine). A parser combinator library for Rust.
+* [TensorFlow Rust](https://github.com/google/tensorflow-rust/). Rust language bindings for TensorFlow.
+
+Number: 154  Date: 2016-11-01 
+
+* The community team is hosting a hybrid hack event on November 19th/20th centered around the African/European time zones. If you are interested in participating, or supplying topics to work on, please head to the [novemb.rs](http://novemb.rs) website.
+* [Spectral fluent assertions 0.5.0 released.](https://github.com/cfrancia/spectral)
+## Other Weeklies from Rust Community
+* [This week in Rust docs 28](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-28). Updates from the Rust documentation team.
+* [This week in TiKV 2016-10-31](http://weekly.pingcap.com/2016/10/31/tidb-weekly/). TiKV is a distributed Key-Value database.
+
+Number: 155  Date: 2016-11-08 
+
+* [Refactoring std for ultimate portability](https://internals.rust-lang.org/t/refactoring-std-for-ultimate-portability/4301).
+* [Crates.io expiry postmortem (2016-11-07)](https://internals.rust-lang.org/t/crates-io-expiry-postmortem-2016-11-07/4344).
+* [Rust and GNOME meeting notes](https://internals.rust-lang.org/t/rust-and-gnome-meeting-notes/4339).
+* [2016 Rust Commercial User Survey results](https://internals.rust-lang.org/t/2016-rust-commercial-user-survey-results/4317).
+* [rustup 0.6.5](https://internals.rust-lang.org/t/beta-testing-rustup-rs/3316/197) is released with new build of curl that fixes security issues.
+## Other Weeklies from Rust Community
+* [This week in Rust docs 29](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-29). Updates from the Rust documentation team.
+* [These weeks in Servo 82](https://blog.servo.org/2016/10/24/twis-82/). Servo is a prototype web browser engine written in Rust.
+* [This week in Ruru 4](http://this-week-in-ruru.org/2016/11/03/this-week-in-ruru-4/). Ruru lets you write native Ruby extensions in Rust.
+* [What's coming up in imag 19](http://beyermatthias.de/blog/2016/11/04/what-s-coming-up-in-imag-19/). imag is a text based personal information management suite.
+* [This week in TiKV 2016-11-07](http://weekly.pingcap.com/2016/11/07/tidb-weekly/#weekly-update-in-tikv). TiKV is a distributed Key-Value database.
+* [PlanetKit week 3: hexagons](https://jeffparsons.github.io/2016/11/05/hexagons/)! PlanetKit generates colorful blobs that might one day resemble planets. ([Week 1](https://jeffparsons.github.io/2016/10/19/introducing-planetkit/) introduces PlanetKit and [week 2](https://jeffparsons.github.io/2016/10/25/week2-basic-terrain/) is about creating basic terrain).
+
+Number: 156  Date: 2016-11-15 
+
+* [Schemers: Build a Scheme Interpreter in Rust - a tutorial for Rust beginners](https://mgattozzi.github.io/2016/11/08/scheme-input.html).
+* [Rapid prototyping C applications with Rust](https://rust-leipzig.github.io/cargo/2016/11/13/rapid-prototyping-c-applications/).
+* [Associated type constructors, part 4: Unifying ATC and HKT](http://smallcultfollowing.com/babysteps/blog/2016/11/09/associated-type-constructors-part-4-unifying-atc-and-hkt/).
+* [Parallel iterators, part 3: Consumers](http://smallcultfollowing.com/babysteps/blog/2016/11/14/parallel-iterators-part-3-consumers/).
+* [A quick tour of Rust’s Type System part 1: Sum Types (a.k.a. Tagged Unions)](https://tonyarcieri.com/a-quick-tour-of-rusts-type-system-part-1-sum-types-a-k-a-tagged-unions).
+* [The fastest template engine in the West](https://lambda.xyz/blog/maud-is-fast/).
+* [Implementing Finite Automata in Rust (Part 2)](https://apanatshka.github.io/compsci/2016/11/12/implementing-finite-automata-part-2/).
+* [Using Rust for ‘scripting’](http://www.chriskrycho.com/2016/using-rust-for-scripting.html).
+
+==============================================================
+Number: 157  Date: 2016-11-22 
+
+* [The MSP430 LLVM backend has been enabled in the latest nightly](https://users.rust-lang.org/t/the-msp430-llvm-backend-has-been-enabled-in-the-latest-nightly-please-test-it/8045).
+* [Rust documentation is now optional and opt-in when installing via rustup](https://users.rust-lang.org/t/psa-rust-documentation-is-now-optional-and-opt-in-when-installing-via-rustup/8072).
+* [Discovery: Discover the world of microcontrollers through Rust](https://users.rust-lang.org/t/discovery-discover-the-world-of-microcontrollers-through-rust/8015)! Discovery is a book about (programming) embedded systems / microcontrollers aimed at people without previous experience with them.
+## Other Weeklies from Rust Community
+* [This week in Rust docs 31](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-31). Updates from the Rust documentation team.
+* [What's coming up in imag (20)](http://beyermatthias.de/blog/2016/11/18/what-s-coming-up-in-imag-20/). imag is a text based personal information management suite.
+* [This week in TiKV 2016-11-21](http://weekly.pingcap.com/2016/11/21/tidb-weekly/#weekly-update-in-tikv). TiKV is a distributed Key-Value database.
+* [This week in PlanetKit 4](https://jeffparsons.github.io/2016/11/18/fix-cracks/). PlanetKit generates colorful blobs that might one day resemble planets.
+
+Number: 158  Date: 2016-11-29 
+
+* [How to speed up the Rust compiler some more](https://blog.mozilla.org/nnethercote/2016/11/23/how-to-speed-up-the-rust-compiler-some-more/).
+* [Rust’s standard hash table types could go quadratic](http://accidentallyquadratic.tumblr.com/post/153545455987/rust-hash-iteration-reinsertion).
+* [Rust’s iterators are inefficient, and here’s what we can do about it](https://medium.com/@veedrac/rust-is-slow-and-i-am-the-cure-32facc0fdcb).
+* [Goto statement considered (mostly) harmless](http://jamey.thesharps.us/2016/11/go-to-statement-considered-harmless.html): Translating C `goto` statements to Rust with Corrode, a C to Rust translator.
+* [This year in nom: 2.0 is here](https://unhandledexpression.com/2016/11/25/this-year-in-nom-2-0-is-here/).
+* [First steps in Nom: Parsing pseudo GLSL](https://maikklein.github.io/post/nom/).
+* [Writing GStreamer Elements in Rust (Part 3)](https://coaxion.net/blog/2016/11/writing-gstreamer-elements-in-rust-part-3-parsing-data-from-untrusted-sources-like-its-2016/). Parsing data from untrusted sources like it’s 2016.
+* [Painless Rust tests and benches on iOS and Android with Dinghy](https://medium.com/snips-ai/dinghy-painless-rust-tests-and-benches-on-ios-and-android-c9f94f81d305).
+* [First Rust+GObject coding session](https://siliconislandblog.wordpress.com/2016/11/22/first-rustgobject-coding-session/).
+## Other Weeklies from Rust Community
+* [This week in Rust docs 32](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-32). Updates from the Rust documentation team.
+* [This week in Tock Embedded OS 9](http://www.tockos.org/blog/2016/talking-tock-9/).  Tock is a safe, multitasking operating system for low-power, low-memory microcontrollers.
+* [This week in Ruma 2016-11-27](https://www.ruma.io/news/this-week-in-ruma-2016-11-27/). Ruma is a Matrix homeserver written in Rust.
+* [This week in TiKV 2016-11-28](http://weekly.pingcap.com/2016/11/28/tidb-weekly/#weekly-update-in-tikv). TiKV is a distributed Key-Value database.
+* [Way Cooler Alpha Update (2016 November)](https://timidger.github.io/way-cooler-2016-november-update.html). Way Cooler is a customizable tiling window manager written in Rust for Wayland.
+
+Number: 159  Date: 2016-12-06 
+
+* [Redox released its first ISO image](https://github.com/redox-os/redox/releases/tag/0.0.3).
+* [Starting a new Rust project right, with error-chain](https://brson.github.io/2016/11/30/starting-with-error-chain).
+* [Reflections on rusting trust](https://manishearth.github.io/blog/2016/12/02/reflections-on-rusting-trust/).
+* [Zero-cost abstractions](https://ruudvanasseldonk.com/2016/11/30/zero-cost-abstractions) in Rust.
+* [Building native macOS applications with Rust](https://blog.bugsnag.com/building-macos-apps-with-rust/).
+* [ripgrep code review](http://blog.mbrt.it/2016-12-01-ripgrep-code-review/) with focus on its design decisions and interesting implementation solutions.
+* [Taking TRust-DNS IntoFuture](https://bluejekyll.github.io/blog/rust/2016/12/03/trust-dns-into-future.html).
+* [WebVR coming to Servo: Architecture and latency optimizations](https://blog.mozvr.com/webvr-servo-architecture-and-latency-optimizations/).
+* [Three bytes and a space: or, Rust bugs, non-compliance, and how I learned to love IRC](https://medium.com/@covabishop/three-bytes-and-a-space-8f9fbd1c669b).
+* [I used to use pointers - now what](https://github.com/diwic/reffers-rs/blob/master/docs/Pointers.md)? Common C pointer patterns, and what to do in Rust instead.
+* [Russian dolls and clean Rust code](https://mgattozzi.com/russian-dolls). Replacing nested pattern matching with `and_then`.
+* [24 days of Rust - cargo subcommands](https://siciarz.net/24-days-rust-cargo-subcommands/).
+* [24 days of Rust - structured logging](https://siciarz.net/24-days-rust-structured-logging/).
+* [24 days of Rust - environment variables](https://siciarz.net/24-days-rust-environment-variables/).
+* [survey] [Crate evaluation user research survey](https://www.surveymonkey.com/r/6TM9ZZM).
+## Other Weeklies from Rust Community
+* [This week in Rust docs 33](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-33). Updates from the Rust documentation team.
+* [This week in TiKV 2016-12-05](http://weekly.pingcap.com/2016/12/05/tidb-weekly/#weekly-update-in-tikv). TiKV is a distributed Key-Value database.
+* [This week in Ruma 2016-12-04](https://www.ruma.io/news/this-week-in-ruma-2016-12-04/). Ruma is a Matrix homeserver written in Rust.
+
+Number: 160  Date: 2016-12-13 
+
+* [How to translate a large C project to Rust](http://jamey.thesharps.us/2016/12/how-to-translate-large-c-project-to-rust.html).
+* [Debian Rust packaging policy (draft)](https://internals.rust-lang.org/t/debian-rust-packaging-policy-draft/4453).
+* [Comparing Diesel and rust-postgres](https://hackernoon.com/comparing-diesel-and-rust-postgres-97fd8c656fdd).
+* [Idiomatic callbacks in Rust](http://stackoverflow.com/a/41081702/265521).
+* [Benchmarks vs. The World](https://llogiq.github.io/2016/12/08/hash.html).
+* [List of unstable feature gates in Rust](https://bot.tinaun.net/rust/featurelist/).
+* [Enforcing drop order in Rust](https://aochagavia.github.io/blog/enforcing-drop-order-in-rust/).
+* [rst 0.3 released, now with a web UI](https://vitiral.github.io/2016/11/30/rst-server.html).
+* [video] [Extending Python with Rust](https://www.youtube.com/watch?v=-ylbuEzkG4M).
+## 24 Days of Rust
+24 days of Rust is a series of articles introducing Rust language features, useful libraries, and cool projects built with Rust. Last week's articles are:
+* [derive_builder](https://siciarz.net/24-days-rust-derive_builder/).
+* [static initialization](https://siciarz.net/24-days-rust-static-initialization/).
+* [serde](https://siciarz.net/24-days-rust-serde/).
+* [winreg](https://siciarz.net/24-days-rust-winreg/).
+* [nom part 1](https://siciarz.net/24-days-rust-nom-part-1/).
+* [nom part 2](https://siciarz.net/24-days-rust-nom-part-2/).
+## Other Weeklies from Rust Community
+* [This week in Rust docs 34](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-34). Updates from the Rust documentation team.
+* [This week in Ruma 2016-12-11](https://www.ruma.io/news/this-week-in-ruma-2016-12-11/). Ruma is a Matrix homeserver written in Rust.
+* [This week in TiKV 2016-12-12](http://weekly.pingcap.com/2016/12/12/tidb-weekly/#weekly-update-in-tikv). TiKV is a distributed Key-Value database.
+* [These weeks in Ruru 5](http://this-week-in-ruru.org/2016/12/10/these-weeks-in-ruru-5/). Ruru lets you write native Ruby extensions in Rust.
+
+Number: 161  Date: 2016-12-20 
+
+* [Rustup 1.0 is released](https://internals.rust-lang.org/t/beta-testing-rustup-rs/3316/203) and is now the default installation method for Rust.
+* [Rust is included in GitHub's _Great for new contributors_ showcase](https://github.com/showcases/great-for-new-contributors).
+* [The Underhanded Rust Contest](https://underhanded.rs/blog/2016/12/15/underhanded-rust.en-US.html). Can you write 100% safe Rust that hides a logic bug, or hide an exploit in unsafe Rust that passes an audit? Now’s your chance!
+* [Idiomatic tree and graph like structures in Rust](https://rust-leipzig.github.io/architecture/2016/12/20/idiomatic-trees-in-rust/).
+* [Prototyping a new 3D Web API for Servo with Vulkan backend](https://kvark.github.io/3d/api/2016/12/17/webmetal.html).
+* [Generating Rust FFI Bindings to C/C++ Libraries at cargo build time in `build.rs` with libbindgen](http://fitzgeraldnick.com/2016/12/14/using-libbindgen-in-build-rs.html).
+* [Rust futures at a glance](https://daiheitan.github.io/blog/2016/12/07/Rust-futures-at-a-glance/).
+* [Writing an Interpreter in Rust](https://chr4.org/blog/2016/12/09/writing-an-interpreter-in-rust/). (And [part 2](https://chr4.org/blog/2016/12/17/writing-an-interpreter-in-rust-part-2/).)
+* [Creating expedient microservices in Rust and Diesel](https://blog.codeship.com/creating-expedient-microservices-in-rust-and-diesel/).
+* [All about arrays](https://llogiq.github.io/2016/12/20/rfcs.html). More ideas around [Alloca for Rust](https://github.com/rust-lang/rfcs/pull/1808) RFC.
+* [Abstracting over mutability in Rust](https://lab.whitequark.org/notes/2016-12-13/abstracting-over-mutability-in-rust/).
+* [Owning collections in heap-less Rust](https://lab.whitequark.org/notes/2016-12-17/owning-collections-in-heap-less-rust/).
+## 24 Days of Rust
+24 days of Rust is a series of articles introducing Rust language features, useful libraries, and cool projects built with Rust. Last week's articles are:
+* [clap](https://siciarz.net/24-days-rust-clap/).
+* [zip & lzma compression](https://siciarz.net/24-days-rust-zip-and-lzma-compression/).
+* [Cursive](https://siciarz.net/24-days-rust-cursive/).
+* [tera](https://siciarz.net/24-days-rust-tera/).
+* [git2](https://siciarz.net/24-days-rust-git2/).
+* [diesel](https://siciarz.net/24-days-rust-diesel/).
+* [error_chain](https://siciarz.net/24-days-rust-error_chain/).
+## Other Weeklies from Rust Community
+* [These weeks in Servo 85](https://blog.servo.org/2016/12/19/twis-85/). Servo is a prototype web browser engine written in Rust.
+* [This week in Rust docs 35](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-35). Updates from the Rust documentation team.
+* [This week in TiKV 2016-12-19](http://weekly.pingcap.com/2016/12/19/tidb-weekly/#weekly-update-in-tikv). TiKV is a distributed Key-Value database.
+* [What's coming up in imag 21](http://beyermatthias.de/blog/2016/12/16/what-s-coming-up-in-imag-21/). imag is a text based personal information management suite.
+* [These weeks in PlanetKit 5](https://jeffparsons.github.io/2016/11/18/twipk-5/). PlanetKit generates colorful blobs that might one day resemble planets.
+
+Number: 162  Date: 2016-12-27 
+
+* [Four years with Rust](http://words.steveklabnik.com/four-years-with-rust).
+* [Rust CI / release infrastructure changes](https://internals.rust-lang.org/t/rust-ci-release-infrastructure-changes/4489).
+* [Getting started with Tokio](https://lukesteensen.com/2016/12/getting-started-with-tokio/).
+* [Complementing Python with Rust](https://medium.com/@caulagi/complementing-python-with-rust-657a8cb3d066).
+* [planet-rust.com](http://www.planet-rust.com), the Rust programming language feeds (planet) powered by [planetrs](https://github.com/Vagdish/planetrs).
+## 24 Days of Rust
+24 days of Rust is a series of articles introducing Rust language features, useful libraries, and cool projects built with Rust. Last week's articles are:
+* [leftpad](https://siciarz.net/24-days-rust-leftpad/).
+* [reqwest](https://siciarz.net/24-days-rust-reqwest/).
+* [app_dirs and preferences](https://siciarz.net/24-days-rust-app_dirs-and-preferences/).
+* [lettre](https://siciarz.net/24-days-rust-lettre/).
+* [built with Rust](https://siciarz.net/24-days-rust-built-rust-2016/).
+* [conclusion](https://siciarz.net/24-days-rust-conclusion-2016/).
+## Other Weeklies from Rust Community
+* [This year in Gfx-rs - 2016](https://gfx-rs.github.io/2016/12/21/this-year.html).
+* [This week in Rust docs 36](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-36).
+* [This week in TiKV 2016-12-26](http://weekly.pingcap.com/2016/12/26/tidb-weekly/#weekly-update-in-tikv).
+
+Number: 163  Date: 2017-01-03 
+
+* [Rust is more than safety](http://words.steveklabnik.com/rust-is-more-than-safety).
+* [Rust is mostly safety](https://graydon2.dreamwidth.org/247406.html).
+* [Safety is Rust's Fireflower](https://thefeedbackloop.xyz/safety-is-rusts-fireflower/).
+* [Fire Mario, not Fire Flowers](http://words.steveklabnik.com/fire-mario-not-fire-flowers).
+* [Rust is about productivity](http://www.ncameron.org/blog/rust-is-about-productivity/).
+* [Rust is its community](https://mgattozzi.com/rust-is).
+* [Why Rust? Sum types](https://insanitybit.github.io/2016/12/28/why-rust-sum-types).
+* [Rust is software's salvation](https://redox-os.org/news/rust-is-softwares-salvation-17/).
+* [Creating an enum iterator using Macros 1.1](https://cbreeden.github.io/Macros11/).
+* [Elegant library APIs in Rust](https://scribbles.pascalhertleif.de/elegant-apis-in-rust.html).
+* [Rust on RTL8710 running FreeRTOS](https://polyfractal.com/post/rustl8710/).
+* [Golang and Rustlang memory safety](https://insanitybit.github.io/2016/12/28/golang-and-rustlang-memory-safety).
+* [Six easy ways to make your crate awesome](http://www.integer32.com/2016/12/27/how-to-make-your-crate-awesome.html).
+* [Constrain API versions statically with traits](https://maikklein.github.io/post/version-trait/).
+* [Rust on the WiFi Pineapple (and OpenWrt)](http://nitschinger.at/Rust-on-the-Wifi-Pineapple-and-OpenWRT/).
+* [Rust: Borrowing, ownership, and lifetimes](https://medium.com/learning-rust/rust-the-tough-part-2ea11ed3693e).
+* [Xargo v0.3.0 released: Build Your Own `std`](https://users.rust-lang.org/t/xargo-v0-3-0-released-build-your-own-std/8571).
+* [podcast] [New Rustacean News 2: Let's talk roadmap! — Rust's achievements in 2016 and goals for 2017](http://www.newrustacean.com/show_notes/news/_2/index.html).
+## Other Weeklies from Rust Community
+* [This week in Rust docs 37](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-37). Updates from the Rust documentation team.
+* [This year in Redox](http://www.redox-os.org/news/this-year-in-redox-18/). Redox is an operating-system written in Rust.
+* [This year in Robigalia](https://robigalia.org/blog/2016/12/27/this-year-in-robigalia.html). Robigalia is a project to create a highly reliable persistent capability OS, continuing the heritage of EROS and Coyotos.
+* [This year in Ruma](https://www.ruma.io/news/this-year-in-ruma-2016-12-31/). Ruma is a Matrix homeserver written in Rust.
+* [This week in Ruma 2017-01-01](https://www.ruma.io/news/this-week-in-ruma-2017-01-01/).
+* [These weeks in PlanetKit #6: the joy of motion](https://jeffparsons.github.io/2016/12/30/movement/). PlanetKit generates colorful blobs that might one day resemble planets.
+
+Number: 164  Date: 2017-01-10 
+
+* [The Rust programming language, in the words of its practitioners](https://brson.github.io/fireflowers/).
+* [Replacing the jet engine while still flying](http://jensimmons.com/post/jan-4-2017/replacing-jet-engine-while-still-flying). Project Quantum: An effort to incrementally add Servo technologies in Firefox.
+* [Exploring _double faults_](http://os.phil-opp.com/double-faults.html). Part of the series [Writing an OS in Rust](http://os.phil-opp.com/).
+* [Announcing Alacritty, a GPU-accelerated terminal emulator](http://blog.jwilm.io/announcing-alacritty/).
+* [Piston: The image library is now pure Rust](http://blog.piston.rs/2017/01/08/the-image-library-is-now-pure-rust/).
+* [A guide to compiling Rust to WebAssembly](https://hackernoon.com/compiling-rust-to-webassembly-guide-411066a69fde).
+* [Should you convert your C project to Rust](http://jamey.thesharps.us/2017/01/which-projects-should-convert-to-rust.html)?
+* [american fuzzy lop’ing Rust](http://blog.troutwine.us/2017/01/06/american-fuzzy-loping-rust/). [american fuzzy lop](https://en.wikipedia.org/wiki/American_fuzzy_lop_(fuzzer)) is a fuzzer that employs genetic algorithms in order to efficiently increase code coverage of the test cases.
+* [Inner workings of a search engine written in Rust](http://fulmicoton.com/posts/behold-tantivy).
+* [SoA (Structure of Arrays) in Rust with macros 1.1](https://maikklein.github.io/post/soa-rust/).
+* [Rust makes implicit invariants explicit](https://medium.com/@robertgrosse/rust-makes-implicit-invariants-explicit-baf4cf17ae50).
+* [The Rust module system is too confusing](https://withoutboats.github.io/blog/rust/2017/01/04/the-rust-module-system-is-too-confusing.html).
+* [Rust at OneSignal](https://onesignal.com/blog/rust-at-onesignal/). OneSignal shares its experience of using Rust in production for more than a year.
+* [Librsvg 2.41.0 requires Rust](https://mail.gnome.org/archives/desktop-devel-list/2017-January/msg00001.html).
+## Other Weeklies from Rust Community
+* [This week in Rust docs 38](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-38).
+* [These weeks in Servo 86](https://blog.servo.org/2017/01/02/twis-86/).
+* [video] [Ferris makes emulators 14](https://www.youtube.com/watch?v=d-dm4z5fJ1U).
+
+Number: 165  Date: 2017-01-17 
+
+* [Announcing Tokio 0.1](https://tokio.rs/blog/tokio-0-1/).
+* [Forensic tool development with Rust](http://getreu.net/public/downloads/doc/forensic-tool-development-with-rust/Forensic-Tool%20Development%20with%20Rust.html) [(pdf)](http://getreu.net/public/downloads/doc/forensic-tool-development-with-rust/Forensic-Tool%20Development%20with%20Rust.pdf).
+* [PEG parser combinators using operator overloading without macros](https://github.com/J-F-Liu/pom/blob/master/doc/article.md).
+* [Rust tidbits: Box is special](https://manishearth.github.io/blog/2017/01/10/rust-tidbits-box-is-special/).
+* [Rust tidbits: What is a lang item](https://manishearth.github.io/blog/2017/01/11/rust-tidbits-what-is-a-lang-item/)?
+* [Let’s stop ascribing meaning to Code Points](https://manishearth.github.io/blog/2017/01/14/stop-ascribing-meaning-to-unicode-code-points/).
+* [Steed: Let’s build a standard library (std) free of C code / dependencies for Linux](https://users.rust-lang.org/t/lets-build-a-standard-library-std-free-of-c-code-dependencies-for-linux/8930).
+* [Remacs: Porting Emacs to Rust](http://www.wilfred.me.uk/blog/2017/01/11/announcing-remacs-porting-emacs-to-rust/).
+* [How do I satisfy the borrow checker](https://m-decoster.github.io//2017/01/16/fighting-borrowchk/).
+* [Rust on Teensy part 1: Bootup to LED](https://branan.github.io/teensy/2017/01/12/bootup.html). PJRC Teensy is a USB-based microcontroller development system.
+* [How to make something public within a crate, but private outside it](http://stackoverflow.com/a/41667202).
+* [Debugging Rust's new Custom Derive system](https://quodlibetor.github.io/posts/debugging-rusts-new-custom-derive-system/).
+* [Announcing Rust Contributors](http://words.steveklabnik.com/announcing-rust-contributors).
+* [Announcing Language team shepherds](https://internals.rust-lang.org/t/language-team-shepherds/4595). Language team is creating a group of _shepherds_, comprising of members of the community with an increased level of trust and responsibility. They will guide discussion on RFCs, mentor RFC authors, and collaborate on improving designs and expositions.
+* [Rust and the limits of swarm design](http://esr.ibiblio.org/?p=7303). Follow-up to - [Rust severely disappoints me](http://esr.ibiblio.org/?p=7294).
+* [video playlist] [Videos from Rust Belt Rust 2016 are now available](https://www.youtube.com/playlist?list=PLgC1L0fKd7UmdG82JOEE0uzXci1XY61xU).
+## Other Weeklies from Rust Community
+* [This week in Rust docs 39](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-39).
+* [This week in Servo 88](https://blog.servo.org/2017/01/16/twis-88/).
+* [This week in Ruma 2017-01-15](https://www.ruma.io/news/this-week-in-ruma-2017-01-15/).
+* [These weeks in Ruru 6](http://this-week-in-ruru.org/2017/01/10/these-weeks-in-ruru-6/).
+* [What's coming up in imag 22](https://beyermatthias.de/blog/2017/01/17/whats-coming-up-in-imag-22/)
+
+Number: 166  Date: 2017-01-24 
+
+* [Announcing Rust Language Server alpha release](http://www.jonathanturner.org/2017/01/rls-alpha-release.html). RLS provides a service that runs in the background, providing IDEs, editors, and other tools with information about Rust programs.
+* [Hyper 0.10 is released which no longer depends on OpenSSL](http://seanmonstar.com/post/156128815358/a-hyper-update), and next release [will bring in non-blocking IO support](https://github.com/hyperium/hyper/commit/2d2d5574a698e74e5102d39b9a9ab750860d92d1).
+* [Parallelizing Enjarify in Go and Rust](https://medium.com/@robertgrosse/parallelizing-enjarify-in-go-and-rust-21055d64af7e). Comparing Go and Rust performance in parallelism ([source code](https://github.com/google/enjarify/tree/go)).
+* [Mitigating underhandedness with Clippy](https://manishearth.github.io/blog/2017/01/21/mitigating-underhandedness-clippy/).
+* [Coroutines and Rust](https://users.rust-lang.org/t/coroutines-and-rust/9058).
+* [Text analysis in Rust: Tokenization](http://nitschinger.at/Text-Analysis-in-Rust-Tokenization/).
+* [Assigning blame to unsafe code](http://smallcultfollowing.com/babysteps/blog/2017/01/22/assigning-blame-to-unsafe-code/).
+* [Defining a ‘handshake’ protocol between two traits](https://withoutboats.github.io/blog/rust/patterns/traits/2017/01/21/handshake-patterns.html).
+* [Short intro to C++ for Rust developers: Ownership and borrowing](https://nercury.github.io/c++/intro/2017/01/22/cpp-for-rust-devs.html).
+* [Using the Borrow Checker to make Tic-Tac-Toe safer](https://lukaskalbertodt.github.io/2017/01/20/abusing-borrowck-to-make-tic-tac-toe-safer.html).
+* [servo/rust-bindgen is now the canonical repository for `bindgen` crate](https://www.reddit.com/r/rust/comments/5pr3t9/heads_up_yamakakyrustbindgen_and_servorustbindgen/).
+* [Categories and CI badges are now available on crates.io](http://www.integer32.com/2017/01/20/categories-and-ci-badges.html).
+## Other Weeklies from Rust Community
+* [This week in Rust docs 40](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-40).
+* [This week in Servo 89](https://blog.servo.org/2017/01/23/twis-89/).
+* [This week in Remacs 2017-01-19](http://www.wilfred.me.uk/blog/2017/01/19/this-week-in-remacs/).
+* [This month in Zone of Control 2017-01-24](https://users.rust-lang.org/t/this-month-in-zone-of-control/6993/2). ZoC is a turn-based hexagonal strategy game.
+* [video] [Ferris makes Emulators 17](https://www.youtube.com/watch?v=0Lq3pj8qxk4): Envelopes and play control.
+
+Number: 167  Date: 2017-01-31 
+
+* [An overview of macros in Rust](http://words.steveklabnik.com/an-overview-of-macros-in-rust).
+* [Lowering Rust traits to logic](http://smallcultfollowing.com/babysteps/blog/2017/01/26/lowering-rust-traits-to-logic/).
+* [Lazy initialization in Rust](http://blog.kylehuey.com/post/156464146312/lazy-initialization-in-rust).
+* [How-to optimize Rust programs on Linux](https://jbendig.github.io/fix-rs/2017/01/24/how-to-optimize-rust-programs-on-linux/).
+* [A guide to porting C/C++ to Rust](https://locka99.gitbooks.io/a-guide-to-porting-c-to-rust/content/).
+* [Building high performance REST APIs with Rust and Rocket](https://github.com/sebasmagri/rocket-loadavg-api/blob/master/README.md).
+* [Building an asynchronous Hyper server](https://mgattozzi.com/hyper-async).
+* [The struggle with Rust](https://ayende.com/blog/176801/the-struggle-with-rust).
+* [Setting expectations for Rust's difficulty](http://www.suspectsemantics.com/blog/2017/01/26/setting-expectations-for-rusts-difficulty/).
+* [Initial Rust support has landed in Apache Thrift](https://www.reddit.com/r/rust/comments/5qbhat/announcement_initial_rust_support_for_thrift/).
+* [Serde 0.9.0](https://github.com/serde-rs/serde/releases/tag/v0.9.0) and [serde_json 0.9.0](https://github.com/serde-rs/json/releases/tag/v0.9.0) released with redesigned error-reporting API, better no_std support, a `json!` macro, and some important breaking changes.
+## Other Weeklies from Rust Community
+* [This week in Rust docs 41](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-41).
+* [This week in Servo 90](https://blog.servo.org/2017/01/30/twis-90/).
+* [video] [Ferris makes Emulators 18](https://www.youtube.com/watch?v=CsQ9WOiHcUQ): Sweep and Mod.
+
+Number: 168  Date: 2017-02-07 
+
+* [Rust's 2017 roadmap](https://blog.rust-lang.org/2017/02/06/roadmap.html).
+* [Announcing Diesel 0.10.0](https://github.com/diesel-rs/diesel/releases/tag/v0.10.0). Diesel now works on Rust stable.
+* [Rocket v0.2](https://rocket.rs/news/2017-02-06-version-0.2/). Managed state & more.
+* [Incremental Compilation is available on nightly and ready for public beta testing](https://internals.rust-lang.org/t/incremental-compilation-beta/4721).
+* [Unsafe code and shared references](http://smallcultfollowing.com/babysteps/blog/2017/02/01/unsafe-code-and-shared-references/).
+* [Communicating intent](https://github.com/jaheba/stuff/blob/master/communicating_intent.md). Understanding _newtype_ pattern, as well as the `From` and `Input` traits.
+* [Writing Python extensions in Rust](https://kushaldas.in/posts/writing-python-extensions-in-rust.html).
+* [Stupid tricks with Rust higher-order functions and "impl trait"](http://integer32.com/2017/02/02/stupid-tricks-with-higher-order-functions.html).
+* [What Rust can do that other languages can't, in six short lines](http://robert.ocallahan.org/2017/02/what-rust-can-do-that-other-languages.html).
+* [Benchmarking Paillier encryption in Rust, C, and more languages](https://medium.com/snips-ai/benchmarking-paillier-encryption-15631a0b5ad8).
+* [Rust on Teensy part 2: Sending a message](https://branan.github.io/teensy/2017/01/28/uart.html). PJRC Teensy is a USB-based microcontroller development system.
+* [This week in Rust docs 42](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-42).
+* [This week in Servo 91](https://blog.servo.org/2017/02/06/twis-91/).
+* [video] [Ferris makes Emulators 19](https://www.youtube.com/watch?v=bhokkyhFcKQ): Sweep and Mod 2.
+
+Number: 169  Date: 2017-02-14 
+
+* [rustc compiler team design sprint -- summary](http://smallcultfollowing.com/babysteps/blog/2017/02/12/compiler-design-sprint-summary/).
+* [Specialization, coherence, and API evolution](https://aturon.github.io/blog/2017/02/06/specialization-and-coherence/).
+* [Safer microcontrollers almost here](http://dylanmckay.io/blog/rust/avr/llvm/2017/02/09/safer-microcontrollers-almost-here.html). Rust on AVR microcontrollers.
+* [Optimizing Rc memory usage in Rust](https://medium.com/@robertgrosse/optimizing-rc-memory-usage-in-rust-6652de9e119e).
+* [Content aware image resizing in Rust](https://mht.technology/post/content-aware-resize/).
+* [How to sanitize your Rust code](https://users.rust-lang.org/t/howto-sanitize-your-rust-code/9378).
+* [Safe Elixir and Erlang NIFs in Rust with Rustlr](http://hansihe.com/2017/02/05/rustler-safe-erlang-elixir-nifs-in-rust.html).
+* [Buffers in Rust](http://rust.fastmail.com.user.fm/2017/02/rusty-buffers/).
+* [What Elm and Rust teach us about the Future](https://dev.to/martincerny/what-elm-and-rust-teach-us-about-the-future).
+* [Chrono 0.3 released, and the future](https://users.rust-lang.org/t/chrono-0-3-released-and-the-future/9340).
+* [This week in Rust docs 43](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-43).
+* [This week in Servo 92](https://blog.servo.org/2017/02/13/twis-92/).
+
+Number: 170  Date: 2017-02-21 
+
+* [Pathfinder, a fast GPU-based font rasterizer in Rust](https://pcwalton.github.io/blog/2017/02/14/pathfinder/).
+* [A simple Rust GUI with QML](https://www.vandenoever.info/blog/2017/02/17/a-simple-rust-gui-with-qml.html).
+* [How copying an int made my code 11 times faster](https://medium.com/@robertgrosse/how-copying-an-int-made-my-code-11-times-faster-f76c66312e0f).
+* [Graphical depiction of ownership and borrowing in Rust](https://rufflewind.com/2017-02-15/rust-move-copy-borrow).
+* [Rust Generic (not Generics)](https://beachape.com/blog/2017/02/04/rust-generic-not-generics/). Write functions that abstract over types and arity, but still have the ability to recover your original type afterwards.
+* [How librsvg exports reference-counted objects from Rust to C](https://people.gnome.org/~federico/news-2017-02.html#how-librsvg-exports-reference-counted-objects).
+* [Writing an interpreter in Rust](https://pliniker.github.io/eval-rs/). A weekly series on writing a toy interpreter in Rust.
+* [Rust tutorial: authz](http://daringordon.com/authz_rs_tutorial/). Learn Rust-specific concepts using a real-world application.
+* [Rust sucks if I fail to write X](https://llogiq.github.io/2017/02/15/sucks.html).
+* [Diesel 0.11 released with MySQL support](https://github.com/diesel-rs/diesel/releases/tag/v0.11.0).
+* [Fireplace is a modular Wayland window manager written in Rust](https://github.com/Drakulix/fireplace).
+* [This week in Rust docs 44](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-44).
+* [This week in Ruma 2017-02-19](https://www.ruma.io/news/this-week-in-ruma-2017-02-19/).
+* [What's coming up in imag 23](https://beyermatthias.de/blog/2017/02/20/whats-coming-up-in-imag-23/).
+
+Number: 171  Date: 2017-02-28 
+
+* [carol10cents has joined the Tooling and Infrastructure team](https://internals.rust-lang.org/t/please-welcome-carols10cents-to-the-tools-team/4830).
+* [Rust is now the fastest language on k-nucleotide](https://benchmarksgame.alioth.debian.org/u64q/performance.php?test=knucleotide). Using [OrderMap](https://github.com/bluss/ordermap) crate, Rust is now the fastest language at The Computer Language Benchmarks Game's k-nucleotide benchmark.
+* [Deploying Rust in a large codebase](https://medium.com/@rillian/deploying-rust-in-a-large-codebase-7e50328074e8). Shipping Rust in Firefox.
+* [Non-lexical lifetimes using liveness and location](http://smallcultfollowing.com/babysteps/blog/2017/02/21/non-lexical-lifetimes-using-liveness-and-location/).
+* [Demangling C++ symbols in Rust](http://fitzgeraldnick.com/2017/02/22/cpp-demangle.html).
+* [Rust asynchronous HTTP server with tokio and hyper](https://blog.guillaume-gomez.fr/articles/2017-02-22+Rust+asynchronous+HTTP+server+with+tokio+and+hyper).
+* [Simulating LIDAR driving with Rust and OpenAI](https://medium.com/@andrew_subarctic/simulating-lidar-driving-with-rust-and-openai-19a8dcbc2ad8).
+* [Shar: One year with Rust](https://www.reddit.com/r/rust_gamedev/comments/5vqlln/shar_one_year_with_rust/). SHAR is an action combination of tactical and sports game in a destructible world.
+* [Objective-C from Rust: Statically verified type encodings without allocation](http://sasheldon.com/blog/2017/02/20/objective-c-from-rust-type-encodings/).
+* [How we made our CSV processing 142x faster](http://blog.faraday.io/how-we-made-our-csv-processing-142x-faster/).
+* [One year with Rust - Developing a full featured application in Rust](https://vitiral.github.io/2017/02/25/one-year-with-rust.html).
+* [The System Programming Enclosure Movement](https://llogiq.github.io/2017/02/21/enclosure.html).
+* [How we made TensorFlow run on a Raspberry Pi using Rust](https://medium.com/snips-ai/how-we-made-tensorflow-run-on-a-raspberry-pi-using-rust-7478f7a31329).
+* [The first Crate polishing workshop: Report](https://llogiq.github.io/2017/02/27/cpw.html).
+## Other Weeklies from Rust Community
+* [This week in Rust docs 45](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-45).
+* [These weeks in Servo 93](https://blog.servo.org/2017/02/27/twis-93/).
+* [These weeks in Redox 19](https://redox-os.org/news/visual-refresh-19/). Visual refresh.
+* [Ferris makes emulators 22: Sample extraction](https://www.youtube.com/watch?v=Cd6yrfI82y8).
+* [What's coming up in imag 23](https://beyermatthias.de/blog/2017/02/20/whats-coming-up-in-imag-23/).
+* [This week in TiKV 2010-02-27](http://weekly.pingcap.com/2017/02/27/tidb-weekly/#weekly-update-in-tikv).
+
+Number: 172  Date: 2017-03-07 
+
+* [Rust's language ergonomics initiative](https://blog.rust-lang.org/2017/03/02/lang-ergonomics.html). To help bring [2017 vision for Rust](https://blog.rust-lang.org/2017/02/06/roadmap.html) to fruition, Rust language team is launching an initiative: improving the ergonomics of the core language.
+* [What are sum, product, and pi types](https://manishearth.github.io/blog/2017/03/04/what-are-sum-product-and-pi-types/).
+* [The future with Futures](http://asquera.de/blog/2017-03-01/the-future-with-futures/). Writing asynchronous Rust with Futures and Tokio.
+* [Designing non-lexical borrows: nested method calls via two-phase borrowing](http://smallcultfollowing.com/babysteps/blog/2017/03/01/nested-method-calls-via-two-phase-borrowing/).
+* [Mitigating underhandedness: Fuzzing your code](https://manishearth.github.io/blog/2017/03/02/mitigating-underhandedness-fuzzing-your-code/).
+* [What I learned from giving a Rust training](http://asquera.de/blog/2017-02-27/rust-training/).
+* [Trying out Rust for graphics programming](http://members.iinet.net.au/~ideasman42/blog/learning_rust.html).
+* [Setting up a Rust development environment](http://asquera.de/blog/2017-03-03/setting-up-a-rust-devenv/).
+* [Rust faster than C? Not so fast…](https://dennisforbes.ca/index.php/2017/03/03/rust-faster-than-c-not-so-fast/). Follow-up to [Rust beating C in The Computer Language Benchmarks Game](https://benchmarksgame.alioth.debian.org/u64q/performance.php?test=knucleotide).
+* [LabelledGeneric in Rust: What, why, how](https://beachape.com/blog/2017/03/04/labelledgeneric-in-rust-what-why-how/)?
+* [RESTful microservices in Rust: Part 1](https://codingwithglee.blogspot.de/2017/02/my-shot-at-restful-microservices-in.html), [part 2](https://codingwithglee.blogspot.de/2017/03/my-shot-at-restful-microservices-in.html) and [part 3](https://codingwithglee.blogspot.de/2017/03/my-shot-at-restful-microservices-in_6.html).
+* [Rust Language Server alpha 2 released bringing new features, better stability, and an easier installation than the first alpha](http://www.jonathanturner.org/2017/03/rls-alpha-2.html).
+* [Redox releases 0.1.1 which adds support for resizing windows, mouse scroll, changing window titles, and improves the look and feel of many Redox applications](https://github.com/redox-os/redox/releases/tag/0.1.1).
+* [video] [Videos from March 2017 Rust Meetup at Mozilla SF](https://air.mozilla.org/rust-meetup-march-2017/). GPU glyph rasterization, Rocket, and the orphan rules.
+* [video] [LLVM Social Berlin #6: Mull meets Rust. Implementing mutation testing system for Rust](https://www.youtube.com/watch?v=VasSufnFswc).
+## Other Weeklies from Rust Community
+* [This week in Rust docs 46](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-46).
+* [This week in Tock Embedded OS 11](https://www.tockos.org/blog/2017/talking-tock-11/).
+
+Number: 173  Date: 2017-03-14 
+
+* [Rust's type system is Turing-complete: An exploration of type-level programming in Rust](https://sdleffler.github.io/RustTypeSystemTuringComplete/). A response to [Rust's type system is not Turing complete](https://www.reddit.com/r/rust/comments/5y4x9r/challenge_rusts_type_system_is_not_turing_complete/) challenge.
+* [Targeting the web with Rust](https://davidmcneil.github.io/the-rusty-web/). A demo web app that implements CPU bound portions in Rust (compiled to wasm/asm.js) while using existing web technologies to handle user facing pieces.
+* [Gentle intro to type-level recursion in Rust: From zero to HList sculpting](https://beachape.com/blog/2017/03/12/gentle-intro-to-type-level-recursion-in-Rust-from-zero-to-frunk-hlist-sculpting/).
+* [Math with distances in Rust: safety and correctness across units](https://ferrisellis.com/posts/rust-implementing-units-for-types/).
+* [Exploring dynamic dispatch in Rust](http://alschwalm.com/blog/static/2017/03/07/exploring-dynamic-dispatch-in-rust/).
+* [Running Rust on the ARM Cortex M3](http://www.acrawford.com/2017/03/09/rust-on-the-cortex-m3.html).
+* [Little tour of multiple iterators implementation in Rust](https://blog.guillaume-gomez.fr/articles/2017-03-09+Little+tour+of+multiple+iterators+implementation+in+Rust).
+* [How to use Hyper HTTP library asynchronously](https://mgattozzi.com/hyper-client).
+* [Building a parallel ECS in Rust](https://kvark.github.io/ecs/rust/2017/03/08/specs.html). The development story of `specs` commemorating the 0.8 version release.
+* [Map of a lifetime](https://llogiq.github.io/2017/03/06/lifetime.html). `flat_map` vs. nested loops.
+* [Reference iterators in Rust](https://medium.com/@jordan_98525/reference-iterators-in-rust-5603a51b5192).
+* [ripgrep 0.5.0 released with UTF-16 support](https://github.com/BurntSushi/ripgrep/releases/tag/0.5.0). ripgrep is a line oriented search tool that combines the usability of The Silver Searcher with the raw speed of GNU grep.
+* [Rust now beats C++ in many benchmarks in The Computer Language Benchmarks Game and is on par in others](https://benchmarksgame.alioth.debian.org/u64q/compare.php?lang=rust&lang2=gpp).
+* [This week in Rust docs 47](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-47).
+* [Parsing into an AST](https://pliniker.github.io/post/eval-rs-04/). Part of the series - [Writing an interpreter in Rust](https://pliniker.github.io/eval-rs/).
+
+Number: 174  Date: 2017-03-21 
+
+* [A gentle introduction to Rust](https://github.com/stevedonovan/gentle-intro). Series of tutorials to get you started with Rust.
+* [Getting started with Piston, a game library for Rust](https://silverwingedseraph.net/programming/2017/03/13/piston-a-game-library-in-rust.html).
+* [Math with distances in Rust: safety and correctness across units](https://ferrisellis.com/posts/rust-implementing-units-for-types/).
+* [Rendering vector map tiles (Rust + asm.js demo)](https://pyfisch.org/blog/rendering-vector-map-tiles/).
+* [ZeroMQ communication between Python and Rust](https://aimlesslygoingforward.com/blog/2017/03/18/zeromq-communication-between-python-and-rust/).
+* [Announcing the tokio-io crate](https://tokio.rs/blog/tokio-io/).
+* [VSCode adds support for ripgrep in latest nightly](https://github.com/Microsoft/vscode/pull/22722). ripgrep is a line oriented search tool written in Rust.
+* [video] [Jeremy Soller, founder of Redox OS - interview](https://www.youtube.com/watch?v=eH5JgMlNE8o).
+* [video] [Rust game demo - Box crash](https://www.youtube.com/watch?v=iEvYlKGlAPs). [Source code](https://github.com/juchiast/boxcrash).
+* [This week in Rust docs 48](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-48).
+* [This week in Servo 95](https://blog.servo.org/2017/03/20/twis-95/).
+
+Number: 175  Date: 2017-03-28 
+
+* [Rust is the most loved language in Stack Overflow Developer Survey, again](https://stackoverflow.com/insights/survey/2017/#most-loved-dreaded-and-wanted).
+* [WebRenderer landed in Firefox Nightly](https://www.reddit.com/r/rust/comments/618p54/webrenderer_landed_in_firefox_nightly_here_is_how/). [WebRender](https://github.com/servo/webrender) is an experimental render backend written in Rust.
+* [Handling exceptions](https://os.phil-opp.com/handling-exceptions.html). Part of the series [Writing an OS in Rust](http://os.phil-opp.com/).
+* [Writing an audio plugin in Rust](https://www.seventeencups.net/writing-an-audio-plugin-in-rust/).
+* [Wouldn't it be neat if you could write C++ inline in Rust](https://mystor.github.io/wouldnt-it-be-neat-p1.html)?
+* [Rust and RPC - OkCupid Hackweek 2017](https://tech.okcupid.com/rust-and-rpc-okcupid-hackweek-2017/).
+* [Unification in Chalk, part 1](http://smallcultfollowing.com/babysteps/blog/2017/03/25/unification-in-chalk-part-1/). Chalk is a PROLOG-ish interpreter written in Rust, intended eventually for use in the compiler.
+* [Polymorphism in Rust: Enum vs Trait + Struct](http://keepcalmandlearnrust.com/2017/03/polymorphism-in-rust-enum-vs-trait-struct/).
+* [Using Rust in Windows](http://www.jonathanturner.org/2017/03/rust-in-windows.html).
+* [How to implement a trait for `&str` and `&[&str]`](https://scribbles.pascalhertleif.de/impl-a-trait-for-str-slices-and-slices-of-strs.html).
+* [Rust support has landed in upstream vim](https://github.com/vim/vim/commit/3c2881dc1195f53ebafc387378399ddd6cb677a7).
+* [Redox 0.1.3 released with better VirtualBox integration](https://github.com/redox-os/redox/releases/tag/0.1.3).
+* [Speakers for RustFest 2017 announced](http://2017.rustfest.eu/talks/). 30 April at Kyiv, Ukraine.
+* [This week in Rust docs 49](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-49).
+
+Number: 176  Date: 2017-04-04 
+
+* [Rust Community team is happy to announce the Rust Community blog](http://blog.community.rs/2017/04/03/welcome.html). Read one of the first posts: [About the Rust Community team](http://blog.community.rs/2017/04/04/about-the-rust-community-team.html).
+* [Mozilla Press Release: Shipping Rust in Firefox](https://blog.mozilla.org/firefox/put-trust-rust-shipping-now-firefox/).
+* [Tor project is considering an incremental migration to Rust](https://lists.torproject.org/pipermail/tor-dev/2017-March/012088.html).
+* [Fuzzing is magic - Or how I found a panic in Rust's regex library](https://www.nibor.org/blog/fuzzing-is-magic---or-how-i-found-a-panic-in-rusts-regex-library/).
+* [Writing a raytracer in Rust](https://bheisler.github.io/post/writing-raytracer-in-rust-part-1/). Part 1: First rays.
+* [Introducing Linkerd-tcp](https://blog.buoyant.io/2017/03/29/introducing-linkerd-tcp/). A TCP load balancer written in Rust with Tokio.
+* [A comparison of regex engines](https://rust-leipzig.github.io/regex/2017/03/28/comparison-of-regex-engines/).
+* [Async, Futures, AMQP, pick three](https://www.clever-cloud.com/blog/engineering/2017/03/28/lapin-new-rust-amqp-library/).
+* [Definitive guide to Rust, SDL 2 and Emscripten](https://blog.fazibear.me/definitive-guide-to-rust-sdl-2-and-emscripten-93d707b22bbb)
+* [Generic numeric functions in safe, stable Rust with the num crate](https://travisf.net/rust-generic-numbers).
+* [Building realtime APIs in Rust](https://lord.io/blog/2017/backtalk/).
+* [Writing GStreamer elements in Rust (part 4)](https://coaxion.net/blog/2017/03/writing-gstreamer-elements-in-rust-part-4-logging-cows-and-plugins/). Logging, COWs and plugins.
+* [This week in Rust docs 50](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-50).
+* [These weeks in Servo 96](https://blog.servo.org/2017/04/03/twis-96/).
+
+Number: 177  Date: 2017-04-11 
+
+* [Iteration patterns for Result & Option](http://xion.io/post/code/rust-iter-patterns.html).
+* [Corrode update: control flow translation correctness](http://jamey.thesharps.us/2017/04/corrode-update-control-flow-translation.html).
+* [Calling Rust from Python](https://bheisler.github.io/post/calling-rust-in-python/).
+* [Notes from the Rust+GNOME hackfest in Mexico City, part 1](https://people.gnome.org/~federico/news-2017-04.html#rust-gnome-hackfest-1).
+* [A demo of calling JavaScript from Rust in WebAssembly](https://github.com/kainino0x/wasm-call-js-from-rust).
+* [zk-SNARKs zero-knowledge proofs in Rust](https://z.cash/blog/bellman-zksnarks-in-rust.html).
+* [Launching a URL shortener in Rust using Rocket](https://matthias-endler.de/2017/rust-url-shortener).
+* [Visual Studio Code 1.11 is released and its text search functionality is powered by ripgrep - a tool written in Rust](https://code.visualstudio.com/updates/v1_11#_text-search-improvements).
+* [Announcing `runtime-fmt`, a crate for using runtime format strings](https://www.platymuus.com/posts/2017/runtime-fmt/).
+* [This week in Rust docs 51](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-51).
+* [This week in Servo 97](https://blog.servo.org/2017/04/10/twis-97/).
+
+Number: 178  Date: 2017-04-18 
+
+* [Carol Nichols and Nick Cameron join the core team, and Patrick Walton retires](https://internals.rust-lang.org/t/announcement-carol-nichols-and-nick-cameron-join-the-core-team-patrick-walton-retires/5070).
+* [Announcing the Rust infrastructure team](https://internals.rust-lang.org/t/announcing-the-unofficial-rust-infrastructure-team/5093).
+* [Updated: Rust language 2017 ergonomic improvements initiative](https://github.com/rust-lang/rust-roadmap/issues/17).
+* [RLS now available on nightly (and via rustup)](http://www.jonathanturner.org/2017/04/rls-now-in-nightly.md.html).
+* [Introducing Relm, a GUI library, based on GTK+ and futures, written in Rust](http://relm.ml/relm-intro).
+* [Optimizing Rust struct size: A 6-month compiler development project](http://camlorn.net/posts/April%202017/rust-struct-field-reordering.html).
+* [As part of MOSS, Mozilla awards $50,000 to Tokio - an asynchronous I/O project in Rust](https://blog.mozilla.org/blog/2017/04/10/mozilla-awards-365000-to-open-source-projects-as-part-of-moss/).
+* [Servo: Windows nightly builds now available](https://blog.servo.org/2017/04/13/windows/).
+* [Prolonging temporaries in Rust](https://manishearth.github.io/blog/2017/04/13/prolonging-temporaries-in-rust/). Telling compiler to hold on to a temporary value for the scope of the outer block.
+* [Rust's fearless concurrency in rdedup](http://dpc.pw/blog/2017/04/rusts-fearless-concurrency-in-rdedup/).
+* [slides] [The end of unsafety: The past, present, and future of the Rust programming language](https://brson.github.io/the-end-of-unsafety/).
+* [Boilerplate-free struct transforms in Rust](https://beachape.com/blog/2017/04/12/boilerplate-free-struct-transforms-in-rust/).
+* [The path to Rust on the web with WebAssembly](http://asquera.de/blog/2017-04-10/the-path-to-rust-on-the-web/).
+* [This week in Servo 98](https://blog.servo.org/2017/04/17/twis-98/).
+* [This week in Rust docs 52](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-52).
+
+Number: 179  Date: 2017-04-25 
+
+* [Announcing Serde 1.0.0 - zero-copy deserialization and remote derive](https://github.com/serde-rs/serde/releases/tag/v1.0.0).
+* [rustc-serialize is deprecated in favour of Serde](https://users.rust-lang.org/t/deprecation-of-rustc-serialize/10485).
+* [Rust MessagePack and Serde 1.0](https://users.rust-lang.org/t/rust-messagepack-and-serde-1-0/10524).
+* [Rust container cheat sheet](https://docs.google.com/presentation/d/1q-c7UAyrUlM-eZyTo1pd8SZ0qwA_wYxmPZVOQkoDmH4/edit?usp=sharing). Visualisation of in-memory representation of Rust types.
+* [A visual guide for rustfmt’s configs](https://github.com/regexident/rustfmt-configs-guide).
+* [Redox OS 0.2.0 - Celebrating 2 years of Redox](https://github.com/redox-os/redox/releases/tag/0.2.0).
+* [Gtk-rs official tutorial is released](http://gtk-rs.org/docs-src/tutorial).
+* [Unification in Chalk, part 2](http://smallcultfollowing.com/babysteps/blog/2017/04/23/unification-in-chalk-part-2/). Chalk is a PROLOG-ish interpreter written in Rust, intended eventually for use in the compiler.
+* [Negative reasoning in Chalk](https://aturon.github.io/blog/2017/04/24/negative-chalk/).
+* [How to fuzz a Rust program](https://medium.com/@daniellockyer/how-to-fuzz-a-rust-program-7adf09d3ab50).
+* [Tricking Rust into following the XDG Base Directory specification](http://zork.net/~st/jottings/Rust_and_the_XDG_Base_Directory_Specification.html).
+* [This week in Rust docs 53](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-53).
+* [This week in Servo 99](https://blog.servo.org/2017/04/24/twis-99/).
+
+Number: 180  Date: 2017-05-02 
+
+* [Helix: Native Ruby extensions without fear](https://usehelix.com/).
+* [bindgen now has a users guide](https://servo.github.io/rust-bindgen/).
+* [Asynchronous Rust for fun & profit](http://xion.io/post/programming/rust-async-closer-look.html).
+* [Rust your ARM microcontroller](http://blog.japaric.io/quickstart/). Build Rust applications for any ARM Cortex-M microcontroller.
+* [Lessons learned redesigning and refactoring a Rust library](https://mgattozzi.com/refactor-rust).
+* [Implementing Weld in Rust](http://dawn.cs.stanford.edu/blog/weld.html).
+* [The RustConf 2017 call for proposals is now open](http://cfp.rustconf.com/events/rustconf-2017).
+* Last week's [visual guide for rustfmt’s configs](https://github.com/regexident/rustfmt-configs-guide) has been [merged into rustfmt project](https://github.com/rust-lang-nursery/rustfmt/blob/master/Configurations.md) along with 120 unit tests.
+* [This week in Rust docs 54](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-54).
+* [This week In Servo 100](https://blog.servo.org/2017/05/01/twis-100/).
+
+Number: 181  Date: 2017-05-09 
+
+* [2017 State of Rust Survey](https://blog.rust-lang.org/2017/05/03/survey.html).
+* [The Rust Libz Blitz](https://blog.rust-lang.org/2017/05/05/libz-blitz.html). Raising a solid core of the Rust crate ecosystem to a consistent level of completeness and quality as part of Rust language 2017 ergonomic improvements initiative.
+* [David Tolnay (of Serde fame) joins the Rust libs team](https://internals.rust-lang.org/t/announcement-david-tolnay-joining-the-libs-team/5186).
+* [How I broke Rust's package manager for all Windows users](http://sasheldon.com/blog/2017/05/07/how-i-broke-cargo-for-windows/).
+* [The pain of real linear types in Rust](https://gankro.github.io/blah/linear-rust/).
+* [The balance between cost, usability, and soundness in C bindings, and Rust-SDL2's release](https://cobrand.github.io/rust/sdl2/2017/05/07/the-balance-between-soundness-cost-useability.html).
+* [gnome-class: Integrating Rust and the GNOME object system](http://smallcultfollowing.com/babysteps/blog/2017/05/02/gnome-class-integrating-rust-and-the-gnome-object-system/).
+* [Fearless concurrency in your microcontroller](http://blog.japaric.io/fearless-concurrency/).
+* [Rust on Teensy part 3: Improving safety](https://branan.github.io/teensy/2017/05/09/safety.html). PJRC Teensy is a USB-based microcontroller development system.
+* [Ownership controls mutability](https://kasma1990.gitlab.io/2017/05/07/ownership-controls-mutability/).
+* [Gtk-rs: New crates.io versions available and API improvements](http://gtk-rs.org/blog/2017/05/06/api-improvements.html).
+* [Rust makes it into a AAA video game!... Sort of](https://twitter.com/alephtwo/status/860665238793986048).
+* [This week in Rust docs 55](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-55).
+* [This week in Servo 101](https://blog.servo.org/2017/05/08/twis-101/).
+
+Number: 182  Date: 2017-05-16 
+
+* [I made a game in Rust](https://michaelfairley.com/blog/i-made-a-game-in-rust/).
+* [Achieving warp speed with Rust](https://gist.github.com/jFransham/369a86eff00e5f280ed25121454acec1). Rust code performance tips.
+* [Two years of Rust](https://blog.rust-lang.org/2017/05/15/rust-at-two-years.html). From Rust's official blog.
+* [Two years of Rust](https://mgattozzi.com/2-years-of-rust).
+* [Going to the edge of space safely, with OpenStratos and Rust](https://medium.com/@Razican/going-to-the-edge-of-space-safely-with-openstratos-and-rust-f58fba8bf151).
+* [The story of a Rust bug — a trip down a rabbit hole](https://thesquareplanet.com/blog/the-story-of-a-rust-bug/).
+* [Implementing an atomic hash table in Rust](https://ticki.github.io/blog/an-atomic-hash-table/).
+* [Mentally modelling Rust modules](https://manishearth.github.io/blog/2017/05/14/mentally-modelling-modules/).
+* [How to write build.rs scripts properly](https://kazlauskas.me/entries/writing-proper-buildrs-scripts.html).
+* [Rust on AVR: Beyond blinking](https://gergo.erdi.hu/blog/2017-05-12-rust_on_avr__beyond_blinking/). AVR is a family of 8-bit microcontrollers.
+* [Implementing an E-Ink clock controlled by an ARM microcontroller (LPC1227) in Rust](https://me.pushrax.com/e-ink-clock/software/).
+* [Writing a GitHub webhook with Rust! Part 1: Rocket](https://medium.com/@aergonaut/writing-a-github-webhook-with-rust-part-1-rocket-4426dd06d45d).
+* [Rust FFI: Sending strings to the outside world](https://thefullsnack.com/en/string-ffi-rust.html).
+* [A simple Rust memory management overview](https://zee-nix.blogspot.in/2017/05/rust-memory-management.html).
+* [Cheatsheet for Future combinators](https://rufflewind.com/img/rust-futures-cheatsheet.html).
+* [All Rustfest Kyiv 2017 talks are now online](https://www.youtube.com/watch?list=PL85XCvVPmGQhvs1Rnet_24B-AI3YSM2YG&v=AHprJNUCgQ0).
+* [nom 3.0 is released](https://github.com/Geal/nom/blob/master/CHANGELOG.md#300---2017-05-12).
+* [This week in Rust docs 56](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-56).
+* [This week in Servo 102](https://blog.servo.org/2017/05/15/twis-102/).
+
+Number: 183  Date: 2017-05-23 
+
+* [Announcing the Infrastructure, Cargo, and Dev Tools teams; disbanding the Tools team](https://internals.rust-lang.org/t/announcing-the-infrastructure-cargo-and-dev-tools-teams-disbanding-the-tools-team/5256).
+* [Rust and CSV parsing](http://blog.burntsushi.net/csv/).
+* [How to: Run Rust code on your NVIDIA GPU](https://github.com/japaric/nvptx#nvptx).
+* [System programming in Rust: Beyond safety](https://www.sigops.org/hotos/hotos17/papers/hotos17-final92.pdf).
+* [TLA + Rust for provably correct and safe distributed systems](https://github.com/spacejam/tla-rust/blob/master/README.md).
+* [Building graphical applications to JS in stable Rust](https://gregkatz.github.io/2017-05-20-rust-emscripten.html).
+* [Walkthrough: Rocket, Diesel and a Postgres database on AWS using Rusoto](https://matthewkmayer.github.io/blag/public/post/rusoto-rds-walkthrough/).
+* [Enforcing documentation in a medium-size Rust project](https://medium.com/@Razican/enforcing-documentation-in-a-medium-size-rust-project-7b6a2a47b6d6).
+* [My first PR for a Rust project](https://medium.com/adventures-in-rust/my-first-pr-for-a-rust-project-364d8c02220b).
+* [This week in Rust docs 57](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-57).
+
+Number: 184  Date: 2017-05-30 
+
+* [@RustStatus](https://twitter.com/RustStatus) - Official Twitter account to track outages of Crates.io, rustup, bors, and nightly breakage.
+* [Announcing Tectonic: A complete, modernized, self-contained TeX/LaTeX engine](https://users.rust-lang.org/t/tectonic-a-complete-modernized-self-contained-tex-latex-engine/11053).
+* [Sccache for caching Rust compilation](https://users.rust-lang.org/t/sccache-for-caching-rust-compilation/10960).
+* [Rust: A Scala engineer's perspective](https://beachape.com/blog/2017/05/24/rust-from-scala/).
+* [Overhead analysis of the RTFM framework](http://blog.japaric.io/rtfm-overhead/). RTFM is a framework for building concurrent applications, for ARM Cortex-M MCUs.
+* [Debug Rust on Windows with Visual Studio Code and the MSVC debugger](https://www.brycevandyk.com/debug-rust-on-windows-with-visual-studio-code-and-the-msvc-debugger/).
+* [Query structure in chalk](http://smallcultfollowing.com/babysteps/blog/2017/05/25/query-structure-in-chalk/). Chalk is a PROLOG-ish interpreter written in Rust, intended eventually for use in the compiler.
+* [Notes on building Noise: a JSON search engine written in Rust](http://damienkatz.net/2017/05/23/notes-on-building-noise-a-json-search-engine-written-in-rust/).
+* [Continuous integration and code coverage report for a Rust project](https://medium.com/@Razican/continuous-integration-and-code-coverage-report-for-a-rust-project-5dfd4d68fbe5).
+* [Rust in TiKV](https://pingcap.github.io/blog/2017/05/27/rust-in-tikv/). TiKV is a distributed Key-Value database written in Rust.
+* [video] [Helix: Build and deploy a Ruby native extension with Rust in 10 minutes](https://www.youtube.com/watch?v=nq1nNx8-fNQ).
+* [Rust support for KDevelop being worked on as a GSoC project](https://perplexinglyemma.blogspot.in/2017/05/summer-of-coding.html).
+* [This week in Rust docs 58](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-58).
+
+Number: 185  Date: 2017-06-06 
+
+* [Rust performance pitfalls](https://llogiq.github.io/2017/06/01/perf-pitfalls.html).
+* [Rustfmt changes](http://www.ncameron.org/blog/rustfmt-changes/). Active development of Rustfmt will become nightly only for a while, and the default formatting will change dramatically.
+* [A web server unikernel in Rust](https://rajiv256.github.io/projects/ouros/).
+* [Global uninitialized statics in Rust](https://mgattozzi.com/global-uninitialized).
+* [Walkthrough: Rocket, Diesel and a Postgres database on AWS using Rusoto, part 2](https://matthewkmayer.github.io/blag/public/post/rusoto-rds-mk2/).
+* [Announcing cargonauts](https://medium.com/@withoutboats/announcing-cargonauts-db5efaaaf7d2). A Rust async web framework.
+* [Announcing Smithay](https://levans.fr/blog/smithay-announce-en.html). A project to build a tooling ecosystem to do wayland apps in rust, both client and server side.
+* [Announcing fd](https://github.com/sharkdp/fd). A simple, fast and user-friendly alternative to find.
+* [This week in Rust docs 59](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-59).
+* [These weeks in Servo 103](https://blog.servo.org/2017/06/05/twis-103/).
+* [This week in Redox 20](https://redox-os.org/news/this-week-in-redox-20/).
+
+Number: 186  Date: 2017-06-13 
+
+* [Rustup 1.4.0 released](https://users.rust-lang.org/t/rustup-1-4-0-released/11268).
+* [How MutexGuard was Sync when it should not have been](https://www.ralfj.de/blog/2017/06/09/mutexguard-sync.html).
+* [Exploring Rust's standard library: system calls and errors](https://people.gnome.org/~federico/blog/rust-libstd-syscalls-and-errors.html).
+* [Exploring MIR Semantics through miri](https://www.ralfj.de/blog/2017/06/06/MIR-semantics.html).
+* [Docs.rs now supports building non-default features](https://github.com/onur/docs.rs/pull/131).
+* [video] ["Rust: Hack without fear!" as the opening talk at C++Now 2017](https://youtu.be/lO1z-7cuRYI).
+* [This week in Redox 21](https://www.redox-os.org/news/this-week-in-redox-21/).
+* [This week in Rust docs 60 ](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-60).
+
+Number: 187  Date: 2017-06-20 
+
+* [RustConf 2017 tickets are now available](https://twitter.com/rustconf/status/874697180778565632).
+* [encoding_rs, a new character encoding conversion library written in Rust, has landed in nightly Firefox](https://twitter.com/hsivonen/status/875043685544718336).
+* [Bugs you'll probably only have in Rust](https://gankro.github.io/blah/only-in-rust/).
+* [Why not to use Rust](https://llogiq.github.io/2017/06/16/no-rust.html).
+* [Algorithms cookbook in Rust](https://github.com/EbTech/rust-algorithms).
+* [Implementing cooperative multitasking in Rust](https://gmorenz.gitlab.io/coop.html).
+* [Switching from C++ to Rust](http://psychopath.io/switching-from-c-to-rust/).
+* [Graphics by squares: a gfx-rs tutorial](https://suhr.github.io/gsgt/).
+* [Rustfmt releases](https://users.rust-lang.org/t/rustfmt-releases/11357). There are some significant changes happening to Rustfmt. Here is what you need to know.
+* [System programming in Rust: beyond safety](https://blog.acolyer.org/2017/06/14/system-programming-in-rust-beyond-safety/).
+* [Writing a LALR(1) parser generator in Rust](https://medium.com/@DmitrySoshnikov/rust-lalr-1-parser-generator-a623b64164e4).
+* [hyper v0.11 is released](http://seanmonstar.com/post/161786147642/hyper-v011).
+* [This week in Redox 22](https://www.redox-os.org/news/this-week-in-redox-22/).
+* [This week in Servo 104](https://blog.servo.org/2017/06/12/twis-104/).
+
+Number: 188  Date: 2017-06-27 
+
+* [A Rust view on Effective Modern C++](https://mainisusuallyafunction.blogspot.in/2017/06/a-rust-view-on-effective-modern-c.html).
+* [The highs and lows of Rust (2017)](https://www.jimmycuadra.com/posts/the-highs-and-lows-of-rust-2017/).
+* [Get Started with Rust, WebAssembly, and Webpack](https://medium.com/@ianjsikes/get-started-with-rust-webassembly-and-webpack-58d28e219635).
+* [Six months of rustc performance (2016-12 ~ 2017-05)](https://www.reddit.com/r/rust/comments/6iusjx/six_months_of_rustc_performance_201612_201705/).
+* [Looping on a member variable without mutably borrowing self](http://blog.ssokolow.com/archives/2017/06/23/rust-looping-on-a-member-variable-without-mutably-borrowing-self/).
+* [Implementing Huffman algorithm in Rust](http://sireliah.com/niusy/rust_huffman/).
+* [A whirlwind tour of rustdoc](https://quietmisdreavus.net/code/2017/06/21/a-whirlwind-tour-of-rustdoc/).
+* [Tock OS: RustConf tutorial preview and SITP retreat](https://www.tockos.org/blog/2017/talking-tock-22/).
+* [rustup 1.5.0](https://users.rust-lang.org/t/rustup-1-5-0-released/11529) is released with support for 'rust-toolchain' file.
+* [This week in Rust docs 61](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-61).
+* [This week in Redox 23](https://redox-os.org/news/this-week-in-redox-23/).
+* [GSoC project: Making Redox self-hosting - status report 1](https://redox-os.org/news/gsoc-self-hosting-1/).
+* [Announcing the Talk Help section](https://users.rust-lang.org/t/announcing-the-talk-help-section/11461). The "Talk Help" section in [TRPLF](https://users.rust-lang.org/) is for discussing conference or meetup talks in all stages, from idea, over proposal to the post-talk feedback.
+* [Rusoto](https://github.com/rusoto/rusoto), an AWS SDK, has a [codegen walkthrough](https://matthewkmayer.github.io/blag/public/post/rusoto-codegen/) that follows code generation from JSON files to Rust code.  [Codegen walkthrough, part two](https://matthewkmayer.github.io/blag/public/post/rusoto-codegen-part-two/).
+* [podcast] [Request for Explanation #0 - What the hell](https://request-for-explanation.github.io/podcast/ep0-what-the-hell/index.html). This week's topic is [RFC 2005](https://github.com/rust-lang/rfcs/blob/master/text/2005-match-ergonomics.md) "Match Ergonomics Using Default Binding Modes".
+# Friends of the Forest
+Our community likes to recognize people who have made outstanding contributions
+to the Rust Project, its ecosystem, and its community. These people are
+'friends of the forest'. The community team has been lax in making nominations for
+this on a regular basis, but we hope to get back on track!
+Today's featured friend of the forest is [Mark Simulacrum](https://github.com/Mark-Simulacrum). As of Friday, June 23, Mark
+has made sure that [all 2,634 open issues on the rust-lang/rust repo](https://github.com/rust-lang/rust/issues) have a label!
+Thank you, Mark, for this heroic effort!
+
+Number: 189  Date: 2017-07-04 
+
+* [Announcing the Increasing Rust's Reach project](https://blog.rust-lang.org/2017/06/27/Increasing-Rusts-Reach.html).
+* [Recapping this week’s Mozilla all-hands](https://internals.rust-lang.org/t/recapping-this-weeks-mozilla-all-hands/5465).
+* [Building a container runtime in Rust](https://blogs.oracle.com/developers/building-a-container-runtime-in-rust).
+* [A Rusty tale of shared memories and passed messages](https://www.worthe-it.co.za/programming/2017/06/19/a-rusty-tale-of-shared-memories-and-passed-messages-1.html).
+* [pdf] [Writing parsers like it is 2017](http://spw17.langsec.org/papers/chifflier-parsing-in-2017.pdf). Writing memory-safe parsers using Rust.
+* [PROST! - A Protocol Buffers implementation for the Rust language](https://github.com/danburkert/prost).
+* [Integrating Rocket and Elm with Brunch](https://medium.com/@frank_27716/integrating-rocket-and-elm-with-brunch-da4680ae7b29).
+* [The new TRust-DNS Resolver](https://bluejekyll.github.io/blog/rust/2017/06/30/trust-dns-resolver.html), quick overview of the new 100% Rust and Tokio based Resolver.
+* [DLL hooking in Rust](https://github.com/Verideth/dll_hook-rs). Rust code to show how hooking in rust with a dll works.
+* [This week in Rust docs 62](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-62).
+* [podcast] [Request for explanation #1 - Constermash](https://request-for-explanation.github.io/podcast/ep1-constermash/index.html).
+* [podcast] [New Rustacean - crates you should know: Rocket](http://www.newrustacean.com/show_notes/cysk/rocket/). An accessible, well-designed web framework in Rust!
+* [video] [Bootstrapping embedded development in Rust by James Munns](https://youtu.be/SOTh6Bu_0OM).
+
+Number: 190  Date: 2017-07-11 
+
+* [Rust's 2017 roadmap, six months in](https://blog.rust-lang.org/2017/07/05/Rust-Roadmap-Update.html).
+* [How Rust is tested](https://brson.github.io/2017/07/10/how-rust-is-tested).
+* [Shipping specialization: a story of soundness](https://aturon.github.io/blog/2017/07/08/lifetime-dispatch/).
+* [RustBelt: Securing the foundations of the Rust programming language](https://www.ralfj.de/blog/2017/07/08/rustbelt.html).
+* [Why you should, actually, rewrite it in Rust](https://unhandledexpression.com/2017/07/10/why-you-should-actually-rewrite-it-in-rust/).
+* [Oracle releases an OCI-Based container runtime in Rust](https://thenewstack.io/oracle-opens-oci-container-runtime).
+* [Speeding up crypto on Wire desktop apps](https://medium.com/@wireapp/speeding-up-crypto-on-wire-desktop-apps-3ff37fc98c3f).
+* [Iterators and Streams in Rust and Haskell](https://www.fpcomplete.com/blog/2017/07/iterators-streams-rust-haskell).
+* [Diesel 0.14.0 released - now supporting arbitrary number of joints and new data types](https://github.com/diesel-rs/diesel/releases/tag/v0.14.0).
+* [My experience with the libz blitz](https://www.reddit.com/r/rust/comments/6lkuyd/my_experience_with_the_libz_blitz/).
+* [Working on Rust Language Server for GSoC 2017](https://xanewok.github.io/gsoc/2017/working-on-rust-language-server/).
+* [GSoC project: Making Redox self-hosting, status report 2](https://redox-os.org/news/gsoc-self-hosting-2/).
+* [The semver trick: how to avoid complicated coordinated upgrades](https://github.com/dtolnay/semver-trick).
+* [A collection of notable Rust blog posts](https://gist.github.com/brson/a324c83a6af6a8a78dfaa9d33eb9b48e).
+* [ggez: A Rust library to create good games easily](http://ggez.rs/).
+* [Monochord: implementing a musical tunings library](http://draft.sx/317fb399adc3c65ac0779df468aa6aa7).
+* [This week in Redox 24](https://redox-os.org/news/this-week-in-redox-24/).
+* [podcast] [Request for Explanation #2 - Stealing chickens on the Internet](https://request-for-explanation.github.io/podcast/ep2-stealing-chickens-on-the-internet/index.html). Discussing the [Evolving Rust through Epochs RFC](https://github.com/rust-lang/rfcs/pull/2052).
+# Friends of the Forest
+Our community likes to recognize people who have made outstanding contributions
+to the Rust Project, its ecosystem, and its community. These people are
+'friends of the forest'.
+Our this week's friend of the forest is [Guillaume Gomez](https://github.com/GuillaumeGomez), whose [influence is evident everywhere you look in Rust](https://users.rust-lang.org/t/twir-friends-of-the-forest/7295/23).
+
+Number: 191  Date: 2017-07-18 
+
+* [The 2017 Rust conference lineup](https://blog.rust-lang.org/2017/07/18/conf-lineup.html).
+* [Ashley and Sebastián join the Rust community team](https://users.rust-lang.org/t/announcing-ashley-and-sebastian-joining-the-community-team/11883)!
+* [ The official Rust Playground now has the top 100 crates available](https://users.rust-lang.org/t/the-official-rust-playground-now-has-the-top-100-crates-available/11817).
+* [The Rustdoc redux](https://internals.rust-lang.org/t/the-rustdoc-redux/5542). A ground-up re-write of rustdoc is coming.
+* [Non-lexical lifetimes: draft RFC and prototype available](http://smallcultfollowing.com/babysteps/blog/2017/07/11/non-lexical-lifetimes-draft-rfc-and-prototype-available/).
+* [Inner workings of a search engine written in Rust part 2: Super fast indexing](http://fulmicoton.com/posts/behold-tantivy-part2/).
+* [Rocket v0.3: Fairings, TLS, and private cookies](https://rocket.rs/news/2017-07-14-version-0.3/).
+* [Avoiding logic bugs in Rust with traits and types](https://mgattozzi.com/avoiding-logic-errors).
+* [How to rewrite your project in Rust](https://unhandledexpression.com/2017/07/12/how-to-rewrite-you-project-in-rust/).
+* [Multithreading in Rust part 2: Pointers to shared memory](https://www.worthe-it.co.za/programming/2017/07/11/a-rusty-tale-of-shared-memories-and-passed-messages-2.html).
+* [Undefined behavior and unsafe code guidelines](https://www.ralfj.de/blog/2017/07/14/undefined-behavior.html).
+* [Building a microservice in Rust (with actors)](https://insanitybit.github.io/2017/07/10/building-a-microservice-in-rust).
+* [Types as contracts](https://www.ralfj.de/blog/2017/07/17/types-as-contracts.html).
+* [Rusoto codegen part three: crategen](https://matthewkmayer.github.io/blag/public/post/rusoto-codegen-part-three/).  Rusoto, an AWS SDK, generates a crate for each AWS service.  This post details how that's done.
+* [Rust On L4Re — Safe Language Meets Safe Microkernel](http://crustulus.de/2017/07/rustonl4re-safelanguagemeetssafekernel/). L4Re is a microkernel featuring strict isolation and virtualisation. The article gives an overview about the porting work.
+* [libsolv - A case study in interfacing with C - Part 1](https://ambaxter.github.io/rust/libsolv/2017/07/14/libsolv-interfaces-part1.html).
+* [This week in Redox 25](https://redox-os.org/news/this-week-in-redox-25/).
+* [This week in Rust docs 64](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-64).
+
+Number: 192  Date: 2017-07-25 
+
+* [Towards a second edition of the compiler](https://internals.rust-lang.org/t/towards-a-second-edition-of-the-compiler/5582).
+* [Introducing PyO3 - Rust bindings for the Python interpreter](https://www.reddit.com/r/rust/comments/6p3rjp/pyo3_python_rust_binding/).
+* [Introducing Tarpaulin - a code coverage tool for Rust](https://xd009642.github.io/2017/07/20/introducing-tarpaulin.html).
+* [Measuring test coverage of Rust libraries](https://jbp.io/2017/07/19/measuring-test-coverage-of-rust-programs).
+* [Using Rocket + error_chain for REST APIs in Rust](https://jamesmunns.com/update/2017/07/22/rocket-plus-error-chain.html).
+* [Gfx-rs - the new low-level core](https://gfx-rs.github.io/2017/07/24/low-level.html).
+* [Supporting workspaces in RLS](https://xanewok.github.io/gsoc/2017/supporting-workspaces-in-rls/).
+* [Making Redox self-hosting, status report 3](https://redox-os.org/news/gsoc-self-hosting-3/).
+* [Making of RustDay Mexico City 2017, a RustBridge day](http://blog.community.rs/2017/07/23/rustdaymx-2017.html).
+* [Rain of Rust – how we did it](http://www.rowdymehul.com/rain-of-rust-how-we-did-it/)?
+* [This week in Rust docs 65](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-65).
+* [This week in Redox 26](https://redox-os.org/news/this-week-in-redox-26/).
+
+Number: 193  Date: 2017-08-01 
+
+* The [Rust Herald](https://herald.community.rs) has been in testing for a while and after fixing some bugs, is now ready for general use. The Herald is meant for small news snippets: your new crate, a meetup announcement, or some short thoughts on a subject. All posts will be shared through RSS and Twitter.
+* [Announcing the “impl period”, Sep 18 - Dec 17](https://internals.rust-lang.org/t/announcing-the-impl-period-sep-18-dec-17/5676).
+* [Revisiting Rust’s modules](https://aturon.github.io/blog/2017/07/26/revisiting-rusts-modules/). ([Discuss here](https://internals.rust-lang.org/t/revisiting-rusts-modules/5628)).
+* [Announcing the `http` crate](https://users.rust-lang.org/t/announcing-the-http-crate/12123).
+* [IntelliJ Rust plugin is now officially supported by JetBrains](https://intellij-rust.github.io/2017/07/31/changelog-47.html).
+* [All contain-rs crates are now in maintenance-mode](https://users.rust-lang.org/t/all-contain-rs-crates-are-now-in-maintenance-mode/12056).
+* [Implementing a bot for Slack in Rust, Rocket and Anterofit - Part 1](https://abishov.com/2017/07/27/hexocat-bot-part-1.html).
+* [Grokking Diesel ORM](https://medium.com/@Buys/grokking-diesel-652cb8886a63).
+* [Parsing NES ROM Headers with nom](https://bheisler.github.io/post/nes-rom-parser-with-nom/).
+* [cortex-m-rtfm v2: simpler, less overhead and more device support](http://blog.japaric.io/rtfm-v2/).
+* [Writing GStreamer applications in Rust](https://coaxion.net/blog/2017/07/writing-gstreamer-applications-in-rust/).
+* [Rust: Not so great for codec implementing](https://codecs.multimedia.cx/?p=1246).
+* [This week in Rust docs 66](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-66).
+* [This week in Redox 27](https://redox-os.org/news/this-week-in-redox-27/).
+
+Number: 194  Date: 2017-08-08 
+
+* [Revisiting Rust’s modules, part 2](https://internals.rust-lang.org/t/revisiting-rust-s-modules-part-2/5700).
+* [RustFest 2017: Supporter tickets on-sale, diversity ticket applications open](http://blog.rustfest.eu/this-week-in-rustfest-5-tickets-diversity).
+* [JetBrains announces official support for Rust plugin for IntelliJ IDEA, CLion, and other JetBrains IDEs](https://blog.jetbrains.com/blog/2017/08/04/official-support-for-open-source-rust-plugin-for-intellij-idea-clion-and-other-jetbrains-ides/).
+* [Building a mobile app in Rust and React Native - part 1](https://medium.com/@marekkotewicz/building-a-mobile-app-in-rust-and-react-native-part-1-project-setup-b8dbcf3f539f).
+* [Asynchronous Rust: complaints & suggestions](https://pro.theta.eu.org/2017/08/04/async-rust.html).
+* [A Stratego interpreter in Rust](http://blog.jeffsmits.net/compsci/2017/08/06/a-stratego-interpreter-in-rust/). Building a faster interpreter for an old language in Rust.
+* [Compile-time safety is for everybody](https://www.tockos.org/blog/2017/apsys-paper/). Follow-up to [Ownership is theft](http://amitlevy.com/papers/tock-plos2015.pdf).
+* [Fearless concurrency with hazard pointers](https://ticki.github.io/blog/fearless-concurrency-with-hazard-pointers/).
+* [Scrapmetal — Scrap your Rust boilerplate](http://fitzgeraldnick.com/2017/08/03/scrapmetal.html).
+* [Rust: Optimising decoder experience](https://codecs.multimedia.cx/2017/08/rust-optimising-decoder-experience/). Follow-up to [Rust: Not so great for codec implementing](https://codecs.multimedia.cx/?p=1246).
+* [This week in Rust docs 67](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-67).
+
+Number: 195  Date: 2017-08-15 
+
+* [Announcing Gotham - a flexible web framework that does not sacrifice safety, security or speed.](https://gotham.rs/blog).
+* [What the RLS can do for Rust support in IDEs](https://www.ncameron.org/blog/what-the-rls-can-do/).
+* [Optimizing Rust](https://blogs.gentoo.org/lu_zero/2017/08/12/optimizing-rust/).
+* [Rust for the web](https://thefullsnack.com/en/rust-for-the-web.html).
+* [Setting up a Rust environment on Windows](https://fungos.github.io/blog/2017/08/12/setting-up-a-rust-environment-on-windows/).
+* [Of boxes and trees - smart pointers in Rust](https://matthias-endler.de/2017/boxes-and-trees/).
+* [Rustls and Servo](https://simrangujral.github.io/Rustls&Servo).
+* [My experience contributing to Servo](http://brainlessdeveloper.com/2017/08/12/my-experience-contributing-to-servo/).
+* [Debugging a race condition in a release target](http://blog.boxofrox.me/2017/08/debugging-a-rust-release-build.html).
+* [Designing a channel](https://stjepang.github.io/2017/08/13/designing-a-channel.html).
+* [Types as contracts: Implementation and evaluation](https://www.ralfj.de/blog/2017/08/11/types-as-contracts-evaluation.html).
+* [Exposing a Rust library to C](http://greyblake.com/blog/2017/08/10/exposing-rust-library-to-c/).
+* [Think local, act local in Rust](https://llogiq.github.io/2017/08/14/local.html).
+* [Announcing Rusty Object Notation](https://kvark.github.io/format/data/json/2017/08/09/rusty-object-notation.html).
+* [Implementing a bot for Slack in Rust, Rocket and Anterofit - Part 2](https://abishov.com/2017/08/08/hexocat-bot-part-2.html).
+* [Evolution of a simple `du -s` clone](https://durka.github.io/blog/2017/08/06/du-evolution.html).
+* [REST calls made rustic: RS-ES in idiomatic Rust tutorial](https://qbox.io/blog/elasticsearch-rest-client-idiomatic-rust-tutorial).
+* [User-friendly Elasticsearch queries with Rust and Elastic](https://qbox.io/blog/user-friendly-elasticsearch-queries-with-rust-and-elastic).
+* [This week in Rust docs 68](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-68).
+* [These weeks in dev-tools 1](https://www.ncameron.org/blog/these-weeks-in-dev-tools-issue-1/).
+* [This week in Redox 28](https://redox-os.org/news/this-week-in-redox-28/).
+
+Number: 196  Date: 2017-08-22 
+
+* [brson - a Rust core team member and a key figure in Rust community is leaving](https://internals.rust-lang.org/t/farewell-rust/5776).
+* [crates.io now renders README files of crates](https://github.com/rust-lang/crates.io/pull/869).
+* [Inside a super fast CSS engine: Quantum CSS (aka Stylo)](https://hacks.mozilla.org/2017/08/inside-a-super-fast-css-engine-quantum-css-aka-stylo/).
+* [rustgo: calling Rust from Go with near-zero overhead](https://blog.filippo.io/rustgo/).
+* [Gtk-rs: The huge and long awaited release is finally here](http://gtk-rs.org/blog/2017/08/20/new-release.html).
+* [RLSL - a new shading language](https://maikklein.github.io/post/shading-language-part1/).
+* [nalgebra - a linear algebra library released v0.13 with pure-rust SVD, LU, Lapack integration, and matrix resizing](https://www.reddit.com/r/rust/comments/6tw57q/nalgebra_v013_released_with_purerust_svd_lu_etc/).
+* [Making Redox self-hosting - status report 4](https://redox-os.org/news/gsoc-self-hosting-4/).
+* [Building a mobile app in Rust and React Native, part 2](https://medium.com/@marekkotewicz/building-a-mobile-app-in-rust-and-react-native-part-2-hello-world-60970a7d194a).
+* [Make docs into code](https://llogiq.github.io/2017/08/20/docs.html).
+* [Announcement - try out Rust IDE support in Visual Studio Code](https://users.rust-lang.org/t/try-out-rust-ide-support-in-visual-studio-code/12407).
+* [Distributing Rust GTK+ Apps](http://blog.ctaggart.com/2017/08/distributing-rust-gtk-apps.html).
+* [Zone of Control is dead. Long life Zemeroth.](https://ozkriff.github.io/2017-08-17--devlog.html). A new turn-based strategy game in Rust.
+* [podcast] [Request for explanation #8 - An existential crisis](https://request-for-explanation.github.io/podcast/ep8-an-existential-crisis/index.html). This week's focus is [RFC 2071](https://github.com/rust-lang/rfcs/pull/2071) "Add impl Trait type alias and variable declarations".
+* [This week in Rust docs 69](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-69).
+
+Number: 197  Date: 2017-08-29 
+
+* [Relaxed-memory concurrency synchronization patterns in Rust](https://jeehoonkang.github.io/2017/08/23/synchronization-patterns.html).
+* [How Glib-rs works, part 1: Type conversions](https://people.gnome.org/~federico/blog/how-glib-rs-works-part-1.html) and [part 2: Transferring lists and arrays](https://people.gnome.org/~federico/blog/how-glib-rs-works-part-2.html).
+* [GSoC: Making Redox self-hosting, final summary](https://redox-os.org/news/gsoc-self-hosting-final/).
+* [GSoC: Wrapping up work on Rust Language Server](https://xanewok.github.io/gsoc/2017/wrapping-up-work-for-gsoc/).
+* [GSoC: Summary of KDevelop Rust plugin development](https://perplexinglyemma.blogspot.com/2017/08/autumn-is-here-wait-this-is-gsoc-not-got.html).
+* [Adventures in logging](https://unhandledexpression.com/2017/08/23/adventures-in-logging/).
+* [Tooling support while using rustc as a library](https://maikklein.github.io/post/rust-compiler/).
+* [Notes from the Rain of Rust campaign](http://abhiramrk.com/its-raining-rust-at-red-hat/).
+* [Rust FFI in a C Wireshark dissector](https://github.com/sevagh/wireshark-dissector-rs/blob/master/README.md).
+* [RustFest Zürich: Announcing first speakers](http://blog.rustfest.eu/this-week-in-rustfest-8-speakers).
+* [This week in Rust docs 70](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-70).
+* [podcast] [Request For explanation #9](https://request-for-explanation.github.io/podcast/ep9-a-once-in-a-lifetime-rfc/index.html). This week's RFC is [RFC 2094: Non-lexical lifetimes](https://github.com/rust-lang/rfcs/pull/2094).
+
+Number: 198  Date: 2017-09-05 
+
+* [Rust 2017 survey results](https://blog.rust-lang.org/2017/09/05/Rust-2017-Survey-Results.html).
+* [Welcome cramertj to the lang team](https://internals.rust-lang.org/t/welcome-cramertj-to-the-lang-team/5844)!
+* [elfmalloc performance evaluation - a pure Rust allocator that's competitive on performance with jemalloc](https://github.com/ezrosent/allocators-rs/blob/master/info/elfmalloc-performance.md).
+* [Announcing Rust Qt binding generator](https://www.vandenoever.info/blog/2017/09/04/rust_qt_binding_generator.html).
+* [Announcing a fast JSON parser which picks up values directly without performing tokenization](https://users.rust-lang.org/t/json-parser-which-picks-up-values-directly-without-performing-tokenization-in-rust/12680).
+* [Getting started with artifact - a design documentation tool](https://github.com/vitiral/artifact/blob/master/docs/QuickStart.md).
+* [5 tips for writing small CLI tools in Rust](https://deterministic.space/rust-cli-tips.html).
+* [Generating C bindings for Rust crates with cbindgen](http://dreamingofbits.com/post/generating-c-bindings-for-rust-crates-with-cbindgen/).
+* [Librsvg's build infrastructure: Autotools and Rust](https://people.gnome.org/~federico/blog/librsvg-build-infrastructure.html).
+* [Replacing a shells script with strongly typed Rust code](https://www.worthe-it.co.za/programming/2017/08/29/writing-git-hooks-using-rust.html).
+* [Outreachy: Wrapping up work on Rust Lifetime Errors](https://medium.com/@geekytwoshoes11/once-a-rustacean-always-a-rustacean-fed0a877472f).
+* [Rust Belt Rust 2017 sessions announced](http://rust-belt-rust.com/sessions.html?year=2017).
+* [This week in Rust docs 71](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-71).
+* [podcast] [Request for explanation #10 - Two paths diverged in a yellow wood](https://request-for-explanation.github.io/podcast/ep10-two-paths-diverged-in-a-yellow-wood/index.html). This week's RFC is [RFC 2126](https://github.com/rust-lang/rfcs/pull/2126) "Clarify and streamline paths and visibility" (aka "The modules RFC").
+* [videos] [Talks from RustConf 2017](https://www.youtube.com/watch?v=COrl851gMTY&list=PL85XCvVPmGQhUSX_QBkxb4g1-o56cCqI9).
+
+Number: 199  Date: 2017-09-12 
+
+* [Writing a command line tool in Rust](https://mattgathu.github.io/writing-cli-app-rust/).
+* [A simple tip to improve Rust program speed](http://vfoley.xyz/rust-compilation-tip/).
+* [Exporting a GObject C API from Rust code and using it from C, Python, JavaScript and others](https://coaxion.net/blog/2017/09/exporting-a-gobject-c-api-from-rust-code-and-using-it-from-c-python-javascript-and-others/).
+* [Futures and gRPC in Rust](https://pingcap.github.io/blog/2017/09/12/futuresandgrpc/).
+* [Rust compile time mandelbrot](http://www.treblig.org/daveG/rust-mand.html).
+* [Rust and QML: a timely example](https://www.vandenoever.info/blog/2017/09/10/time_for_rust_and_qml.html).
+* [How glib-rs works, part 3: Boxed types](https://people.gnome.org/~federico/blog/how-glib-rs-works-part-3.html).
+* [Signed vs unsigned: On integer types in Rust](https://medium.com/@marcinbaraniecki/on-integer-types-in-rust-b3dc1b0a23d3).
+* [This week in Rust docs 72](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-72).
+
+Number: 200  Date: 2017-09-19 
+
+* [impl Future for Rust](https://blog.rust-lang.org/2017/09/18/impl-future-for-rust.html). Announcing the Rust "Impl period"!
+* [Josh Triplett joins the Cargo team](https://internals.rust-lang.org/t/please-welcome-josh-triplett-to-the-cargo-team/5898).
+* [Discover the world of microcontrollers through Rust](https://japaric.github.io/discovery/).
+* [Rust By Example has been ported to mdBook](https://github.com/rust-lang/rust-by-example/pull/897).
+* [Rust is one of the most energy efficient languages](https://sites.google.com/view/energy-efficiency-languages).
+* [This week in Rust docs 73](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-73).
+* [podcast] [New Rustacean - crates you should know: Rayon](http://www.newrustacean.com/show_notes/cysk/rayon/). Safe, threaded, parallel code in Rust!
+
+Number: 201  Date: 2017-09-26 
+
+* [Security advisory for crates.io, 2017-09-19](https://users.rust-lang.org/t/security-advisory-for-crates-io-2017-09-19/12960).
+* [kennytm joins the Rust infrastructure team](https://internals.rust-lang.org/t/please-welcome-kennytm-to-the-infrastructure-team/5944).
+* [How the RLS works](https://www.ncameron.org/blog/how-the-rls-works/).
+* [An RFC for a Tokio revamp](https://tokio.rs/blog/tokio-reform/).
+* [Rewriting a Java application in Rust](https://blog.rom1v.com/2017/09/gnirehtet-rewritten-in-rust/).
+* [The impl period newsletter, week 1](https://internals.rust-lang.org/t/the-impl-period-newsletter-week-1/5971).
+* [This week in Rust docs 74](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-74).
+* [These weeks in dev-tools, issue 2](https://www.ncameron.org/blog/these-weeks-in-dev-tools-issue-2/).
+* [This week in Redox 29](https://redox-os.org/news/this-week-in-redox-29/).
+* [podcast] [Request for explanation 11 - Cargo culting the build system](https://request-for-explanation.github.io/podcast/ep11-cargo-culting-the-build-system/index.html). This week's topic is [eRFC 2136](https://github.com/rust-lang/rfcs/pull/2136) "Cargo build system integration".
+
+Number: 202  Date: 2017-10-03 
+
+* [The 2016 Underhanded Rust Contest results](http://blog.community.rs/underhanded/2017/09/27/underhanded-results.html).
+* [How `Future` works](https://gist.github.com/Diggsey/6f924bf3f741bcdffd240faee102fe92).
+* [Attacking Rust for fun and profit](https://avadacatavra.github.io/rust/gdb/exploit/2017/09/26/attackingrustforfunandprofit.html).
+* [Calling Rust from C#](https://dev.to/living_syn/calling-rust-from-c-6hk).
+* [Testing a Rust command line tool](https://mattgathu.github.io/testing-rust-cli-apps/).
+* [This year in the Amethyst game engine](https://www.amethyst.rs/2017/09/16/twia-10.html).
+* [This week in Rust docs 75](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-75).
+* [RustFest Spring 2018 will be in Paris](https://twitter.com/rustlang/status/914169823009103872).
+
+Number: 203  Date: 2017-10-10 
+
+* [Red Hat adds Go, Clang/LLVM, Rust compiler toolsets; updates GCC](https://developers.redhat.com/blog/2017/10/04/red-hat-adds-go-clangllvm-rust-compiler-toolsets-updates-gcc/).
+* [An opinionated guide to Rust web servers](https://wiki.alopex.li/AnOpinionatedGuideToRustWebServers).
+* [Creating and printing a TypeScript AST from Rust](http://blog.ctaggart.com/2017/10/creating-and-printing-typescript-ast.html).
+* [This week in Rust docs 76](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-76).
+
+Number: 204  Date: 2017-10-17 
+
+* [IntelliJ Rust 0.2.0 released](https://users.rust-lang.org/t/intellij-rust-0-2-0-released/13419).
+* [str vs String](http://www.ameyalokare.com/rust/2017/10/12/rust-str-vs-String.html).
+* [A little story about the `yes` Unix command](https://matthias-endler.de/2017/yes/).
+* [Squeezing Rust into production for real time audio analysis](http://www.tzaeru.com/squeezing-rust-into-production-part-2/).
+* [pdf] [The case for writing a kernel in Rust](https://www.cs.virginia.edu/~bjc8c/papers/levy17rustkernel.pdf).
+* [Exploring lock-free Rust](https://morestina.net/blog/742/exploring-lock-free-rust-1-locks).
+* [It's gfx-rs aLL the way down](https://users.rust-lang.org/t/its-gfx-rs-all-the-way-down/13339) - an interim update on the LL rewrite progress.
+* [Multi-platform Rust and Emscripten specific functions](https://www.worthe-it.co.za/programming/2017/10/10/multiplatform-rust-and-emscripten-specific-functions.html).
+* [The impl period newsletter #2](https://internals.rust-lang.org/t/the-impl-period-newsletter-2/6034).
+* [This week in Rust docs 77](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-77).
+* [This week in Redox 30](https://www.redox-os.org/news/this-week-in-redox-30/).
+* [podcast] [Rusty Spike Podcast - Episode 3](http://castbox.fm/episode/Episode-3-%E2%80%93-Oct-11%2C-2017-id1065347-id53530474?country=gb).
+
+Number: 205  Date: 2017-10-24 
+
+* [Building a cross-platform game in Rust](https://www.reddit.com/r/rust/comments/78bowa/hey_this_is_kyren_from_chucklefish_we_make_and/).
+* [Rust to WebAssembly, made easy](https://lord.io/blog/2017/wargo/).
+* [HolyJit: A JIT for Firefox's and Servo's JS engine written in Rust](https://blog.mozilla.org/javascript/2017/10/20/holyjit-a-new-hope/).
+* [Rust with session types for safe & high-performance codecs](https://polysync.io/blog/session-types-for-hearty-codecs/).
+* [Nightly rustdoc is changing markdown rendering, here's some common differences and how to fix them](https://blog.guillaume-gomez.fr/articles/2017-09-18+New+rustdoc+rendering+common+errors).
+* [How to deploy a Rocket application to Heroku](http://www.duelinmarkers.com/2017/10/21/how-to-deploy-a-rocket-application-to-heroku.html)
+* [Test driven development with Rust](https://matthewkmayer.github.io/blag/public/post/tdd-with-rust/).
+* [This week in Rust docs 78](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-78).
+* [podcast] [Rusty Spike Podcast - Episode 4](https://rusty-spike.blubrry.net/2017/10/18/episode-4-oct-18-2017/). Rust 1.21 release, popularity of the O’Reilly Rust book, GitHub Octoverse, module counts, and Servo adding JetStream.
+
+Number: 206  Date: 2017-10-31 
+
+* [Fun facts about Rust's growing popularity](http://www.jonathanturner.org/2017/10/fun-facts-about-rust-growth.html).
+* [Cargo alternative registries](https://boats.gitlab.io/blog/post/2017-10-28-alternative-registries/).
+* [A game developer's experience with writing a plant simulation game in Rust](https://www.reddit.com/r/rust/comments/795dg4/i_spent_the_last_year_writing_a_plant/).
+* [A brief history of Rust](http://slides.com/bstrie/triangle-rust-history).
+* [The Expressive C++17 coding challenge… in Rust](http://words.steveklabnik.com/the-expressive-c-17-coding-challenge-in-rust).
+* [Announcing bindgen 0.31.0](https://www.reddit.com/r/rust/comments/795n0k/announcing_bindgen_0310/).
+* [Pleco: Creating a Chess engine with Rust](https://sfleischman105.github.io/2017/10/26/creating-a-chess-engine.html).
+* [Swagger.io can now autogenerate Rust servers from OpenAPI specifications](https://www.metaswitch.com/the-switch/metaswitch-swagger-codegen-for-rust-accepted-upstream).
+* [This week in Rust docs 79](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-79).
+* [podcast] [Rusty Spike Podcast - Episode 5](https://rusty-spike.blubrry.net/2017/10/25/episode-5-oct-25-2017/). A new game written in Rust, improvements to WASM support, a JIT compiler in Rust, and Gstreamer support in Servo.s
+
+Number: 207  Date: 2017-11-07 
+
+* [AMA with Rust Language team](https://hashnode.com/ama/with-rust-language-team-cj99mv7s101yw4rwtk5zntk8k).
+* [Accepted RFCs are now available to read in a book format](https://rust-lang.github.io/rfcs/).
+* [Multithreading in Rust with MPSC (Multi-Producer, Single Consumer) channels](https://blog.softwaremill.com/multithreading-in-rust-with-mpsc-multi-producer-single-consumer-channels-db0fc91ae3fa).
+* [Obtaining and using Microsoft's link.exe on Linux+Wine with Rust](https://gist.github.com/est31/7235ab253554d33046873dfb64e7ecdc).
+* [Custom static assertions in Rust](https://nikolaivazquez.com/posts/programming/rust-static-assertions/).
+* [When will the RLS be released](https://www.ncameron.org/blog/when-will-the-rls-be-released/)?
+* [Portability concerns with Path](https://udoprog.github.io/rust/2017-11-05/portability-concerns-with-path.html).
+* [Simple event hooks in Rust](https://mattgathu.github.io/simple-events-hook-rust/).
+* [This week in Rust docs 80](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-80).
+* [video playlist] [Talks from RustFest Zürich 2017](https://www.youtube.com/watch?v=jywiVWKm1TI&list=PL85XCvVPmGQj9mqbJizw-zi-EhcpS5jTP).
+* [podcast] [Rusty Spike Podcast - Episode 6](https://rusty-spike.blubrry.net/2017/11/02/episode-6-nov-1-2017/). Cisco using Rust, StackOverflow’s survey, alternative registries, more NLL news, fun facts about Rust, and SpiderMonkey and Rust.
+
+Number: 208  Date: 2017-11-14 
+
+* [Fearless concurrency in Firefox Quantum](https://blog.rust-lang.org/2017/11/14/Fearless-Concurrency-In-Firefox-Quantum.html).
+* [Zoxc joins Rust compiler team](https://internals.rust-lang.org/t/please-welcome-zoxc-to-the-compiler-team/6207).
+* [Rust futures: a short tutorial - part 1](https://dev.to/mindflavor/rust-futures-an-uneducated-short-and-hopefully-not-boring-tutorial---part-1-3k3).
+* [Cross-compiling Rust for the Raspberry Pi on macOS](https://akappel.github.io/2017/11/07/rpi-crosstool.html).
+* [A linear hashing implementation in Rust](https://samrat.me/posts/2017-11-09-kvstore-rust-hashtable/).
+* [This week in Rust docs 81](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-81).
+* [Impl period newsletter 3](https://internals.rust-lang.org/t/impl-period-newsletter-3/6185).
+* [video] [How Rust gets polymorphism right](https://www.youtube.com/watch?v=VSlBhAOLtFA).
+* [podcast] [Rusty Spike Podcast - episode 7](https://rusty-spike.blubrry.net/2017/11/08/episode-7-nov-8-2017/). Stanford using Rust, the Rust AMA, RLS release dates, crates.io growth, and Servo audio.
+
+Number: 209  Date: 2017-11-21 
+
+* [Nightly Rust compiler and Cargo now run on Redox](https://www.redox-os.org/news/this-week-in-redox-32/).
+* [Announcing Failure](https://boats.gitlab.io/blog/post/2017-11-16-announcing-failure/).
+* [Speed up your Python using Rust](https://developers.redhat.com/blog/2017/11/16/speed-python-using-rust/).
+* [Evolving Rust with Milksnake](https://blog.sentry.io/2017/11/14/evolving-our-rust-with-milksnake).
+* [Crates.io ecosystem not ready for embedded Rust](https://www.tockos.org/blog/2017/crates-are-not-safe/).
+* [This week in Rust docs 82](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-82).
+* Notes from Rust+GNOME Hackfest in Berlin - by [Federico](https://people.gnome.org/~federico/blog/rust-gnome-hackfest-berlin.html), [Guillaume](https://blog.guillaume-gomez.fr/articles/2017-11-18+Rust%2BGNOME+Hackfest+in+Berlin), and [Antoyo](http://antoyo.ml/rust-gnome-hackfest-november).
+* [podcast] [Rusty Spike Podcast - episode 8](https://rusty-spike.blubrry.net/2017/11/16/episode-8-nov-15-2017/). Firefox Quantum, Lin’s Quantum post, fearless concurrency, incremental typecheck, better wasm support, and Cargo on Redox.
+
+Number: 210  Date: 2017-11-28 
+
+* [GTK Rust tutorials - a series](https://mmstick.github.io/gtkrs-tutorials/).
+* [Writing fast and safe native Node.js modules with Rust](https://blog.risingstack.com/node-js-native-modules-with-rust/).
+* [Improving Ruby performance with Rust](https://blog.codeship.com/improving-ruby-performance-with-rust/).
+* [This week in Rust docs 83](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-83).
+* [podcast] [New Rustacean News: Rust 1.21 and 1.22](http://www.newrustacean.com/show_notes/news/rust_1_21_1_22/index.html). Quality of life improvements, Failure, wasm, and rustdoc fun – or, a bunch of highlights from the new releases *and* the community since 1.20.
+* [podcast] [Rusty Spike Podcast - episode 9](https://rusty-spike.blubrry.net/2017/11/22/episode-9-nov-22-2017/). We chat about impl trait, Rust/GNOME hackfest, memory layouts, Visual Studio, failure, suricata, wasm, and some feel-good news.
+
+Number: 211  Date: 2017-12-05 
+
+* [Rust Playground can now output in WebAssembly](https://play.rust-lang.org/?gist=ffb83a685e4aa842527e38569bf23f36&version=nightly).
+* [Building and deploying a Rust library on Android](https://mozilla.github.io/firefox-browser-architecture/experiments/2017-09-21-rust-on-android.html).
+* [Building and deploying a Rust library on iOS](https://mozilla.github.io/firefox-browser-architecture/experiments/2017-09-06-rust-on-ios.html).
+* [Boiling the ocean, incrementally - How Stylo brought Rust and Servo to Firefox](http://bholley.net/blog/2017/stylo.html).
+* [Mercurial's oxidation plan: Using Rust in Mercurial](https://www.mercurial-scm.org/wiki/OxidationPlan).
+* [Diesel: Schema in depth](http://diesel.rs/guides/schema-in-depth/).
+* [The rise of Rust in Dev/Ops](https://mesosphere.com/blog/rust-devops/).
+* [What's a reference in Rust](https://jvns.ca/blog/2017/11/27/rust-ref/)?
+* [Replacing Elasticsearch with Rust and SQLite](https://nbsoftsolutions.com/blog/replacing-elasticsearch-with-rust-and-sqlite).
+* [Rust comes to RISC-V](https://abopen.com/news/rust-comes-risc-v/).
+* [Rust on ARM Cortex-M microcontrollers](http://pramode.in/2017/12/04/rust-on-arm-cortexm-microcontrollers/).
+* [Writing a Brainfuck interpreter in Rust (and WebAssembly)](https://shr.ite.sh/brainfuck-rust-wasm.html).
+* [Learning Rust: Modules, crates, workspaces, std modules, and preludes](https://medium.com/learning-rust/rust-lets-get-it-started-bdd8de58178d).
+* [Rocket - A Rust game running on WebAssembly](https://aochagavia.github.io/blog/rocket---a-rust-game-running-on-wasm/).
+* [Failure 0.1.1 released: Now with `bail!` and `ensure!`](https://boats.gitlab.io/blog/post/2017-11-30-failure-0-1-1/).
+* [Writing a turn-based strategy game in Rust: Progress report](https://ozkriff.github.io/2017-12-01--devlog.html).
+* [The impl period newsletter #4](https://internals.rust-lang.org/t/the-impl-period-newsletter-4/6313).
+* [This week in Rust docs 84](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-84).
+* [podcast] [Rusty Spike Podcast - episode 10](https://rusty-spike.blubrry.net/2017/11/30/episode-10-nov-29-2019/). Rust 1.22, RISC-V, impl newsletter #4, more WASM work, Fennec and Stylo, and Bobby Holley’s Stylo writeup.
+
+Number: 212  Date: 2017-12-12 
+
+* [Rust and the case for WebAssembly in 2018](https://mgattozzi.com/rust-wasm).
+* [Introducing TQL - An easy-to-use ORM for Rust](http://antoyo.ml/tql-easy-orm).
+* [Introducing Conduit - A service mesh for Kubernetes written in Rust](https://buoyant.io/2017/12/05/introducing-conduit/).
+* [Running Rust regex engine on JVM, via WebAssembly](https://github.com/cretz/asmble/tree/master/examples/rust-regex).
+* [A tutorial on how to use Diesel ORM in Rust](http://spejss.com/index.php/2017/12/06/how-to-use-diesel-orm-in-rust/).
+* [This week in Rust docs 85](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-85).
+* [video] [Why Rust is successful](https://www.youtube.com/watch?v=-Tj8Q12DaEQ).
+* [podcast] [Rusty Spike Podcast - episode 11](https://rusty-spike.blubrry.net/2017/12/07/episode-11-dec-6-2017/). Fedora, Conduit, a WebAssembly game, The Playground, Criterion.rs, Diesel, Mercurial, Android, and iOS.
+
+Number: 213  Date: 2017-12-19 
+
+* [Announcing Rust extension for Visual Studio 2017 with RLS support](https://marketplace.visualstudio.com/items?itemName=DanielGriffen.Rust).
+* [Firefox nightly's JavaScript debugger now supports debugging and source maps for Rust compiled to WebAssembly](https://twitter.com/slsoftworks/status/941400137921949696).
+* [stdweb now supports wasm32-unknown-unknown - access the DOM and call into JavaScript from Rust](https://github.com/koute/stdweb).
+* [winapi 0.3 deprecates the `-sys` crates and now has everything in a single crate](https://retep998.github.io/blog/winapi-0.3/).
+* [faster 0.3 released with new license, docs, examples, and much more](https://github.com/AdamNiederer/faster).
+* [Tokio internals: Understanding Rust's asynchronous I/O framework from the bottom up](https://cafbit.com/post/tokio_internals/).
+* [Writing a CHIP-8 emulator with Rust and WebAssembly](http://blog.scottlogic.com/2017/12/13/chip8-emulator-webassembly-rust.html).
+* [This week in Rust docs 86](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-86).
+* [This week in Redox 33](https://redox-os.org/news/this-week-in-redox-33/).
+* [video] [Rust: Reach further (by Nicholas Matsakis)](https://www.youtube.com/watch?v=ksirw1v5gXk).
+* [podcast] [Rusty Spike Podcast - episode 12](https://rusty-spike.blubrry.net/2017/12/13/episode-12-dec-13-2017/). Visual Studio support for Rust, ProPublica’s ad tool, and Mozilla’s growing support.
+
+Number: 214  Date: 2017-12-26 
+
+* [Rust in 2017: what we achieved](https://blog.rust-lang.org/2017/12/21/rust-in-2017.html).
+* [Five years with Rust](http://words.steveklabnik.com/five-years-with-rust).
+* [mrustc - a Rust compiler written in C++ can now build rustc from a source tarball](https://www.reddit.com/r/rust/comments/7lu6di/mrustc_alternate_rust_compiler_in_c_now_broken/).
+* [Introducing May - a stackful coroutine library in Rust](https://blog.zhpass.com/2017/12/23/may-announcement/).
+* [Introducing YEW - a framework for making Elm/React/Angular-like client web-apps with Rust](https://users.rust-lang.org/t/yew-a-framework-for-client-side-web-apps/14597).
+* [Debugging a segfault in a Rust program](https://jvns.ca/blog/2017/12/23/segfault-debugging/).
+* [Undefined vs unsafe in Rust](https://manishearth.github.io/blog/2017/12/24/undefined-vs-unsafe-in-rust/).
+* [The final impl period newsletter](https://internals.rust-lang.org/t/the-final-impl-period-newsletter/6408).
+* [podcast] [Rusty Spike Podcast - episode 13](https://rusty-spike.blubrry.net/2017/12/13/episode-12-dec-13-2017/). Debugging WASM->Rust, more Google tools, stdweb, NLL, and tokio.
+* [podcast] [New Rustacean: Increasing Rust's reach – Anna Liao](http://www.newrustacean.com/show_notes/interview/irr_2017/anna_liao/index.html), on Anna's experience learning Rust while porting a Raspberry Pi Python project as part of the Increasing Rust’s Reach 2017 program.
+* [podcast] [New Rustacean: Increasing Rust's reach – Lee Baillie](http://www.newrustacean.com/show_notes/interview/irr_2017/lee_baillie/index.html), on Lee's experience designing a new website for Rust.
+
+Number: 215  Date: 2018-01-02 
+
+* [Not explicit](https://boats.gitlab.io/blog/post/2017-12-27-things-explicit-is-not/). What it means for Rust syntax to be explicit.
+* [Porting a roguelike game to WebAssembly](https://aimlesslygoingforward.com/blog/2017/12/25/dose-response-ported-to-webassembly/).
+* [Simulating conditional enum variants in Rust](https://rreverser.com/conditional-enum-variants-in-rust/).
+* [Rust IDE + REPL In Vim](https://startupsventurecapital.com/rust-ide-repl-in-vim-11daa921a2c4).
+* [Making TRust-DNS faster than BIND9](https://bluejekyll.github.io/blog/rust/2017/12/29/making-trust-dns-fast.html).
+* [Diesel 1.0 released](https://github.com/diesel-rs/diesel/releases/tag/v1.0.0).
+* [Announcing `ndarray` version 0.11.0](https://jim.turner.link/pages/ndarray-0.11/).
+* [This year in Gfx-rs 2017](http://gfx-rs.github.io/2017/12/30/this-year.html).
+* [This week in Redox 34](https://redox-os.org/news/this-week-in-redox-34/).
+
+Number: 216  Date: 2018-01-09 
+
+* [New year's Rust: A call for community blogposts](https://blog.rust-lang.org/2018/01/03/new-years-rust-a-call-for-community-blogposts.html).
+* [Announcing Diesel 1.0 — a safe, extensible query builder and ORM](https://medium.com/@sgrif/announcing-diesel-1-0-a-safe-extensible-query-builder-and-orm-15e6bd8a9ed0).
+* [Ashley Williams joins the Core Team and taking lead of the Community Team](https://internals.rust-lang.org/t/announcement-ashley-williams-joins-the-core-team-and-taking-lead-of-the-community-team/6453).
+* [Lessons from the impl period](http://smallcultfollowing.com/babysteps/blog/2018/01/05/lessons-from-the-impl-period/).
+* [How to use Rust non lexical lifetimes on nightly](https://santiagopastorino.com/how-to-use-rust-non-lexical-lifetimes-on-nightly/).
+* [A proof-of-concept GraphQL server framework for Rust](https://www.ncameron.org/blog/a-proof-of-concept-graphql-server-framework-for-rust/).
+* [Web scraping with Rust](https://codeburst.io/web-scraping-in-rust-881b534a60f7). A beginner-friendly tutorial highlighting Rust’s viability as a scripting language for everyday use.
+* [This week in Rust docs 87](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-87).
+* [podcast] [New Rustacean: News – Rust 1.23](http://www.newrustacean.com/show_notes/news/rust_1_23/) – Rustdoc changes, the first impl period, Firefox Quantum, and more wasm! (Also note the [`Script` struct docs](http://www.newrustacean.com/show_notes/news/rust_1_23/struct.Script.html) if you prefer reading to listening!)
+* [videos] [Videos from Rust Belt Rust 2017 are now available](https://www.youtube.com/playlist?list=PLgC1L0fKd7Ul71lD_cImGuMxsZ6J8fa06).
+## #Rust2018
+* [2018 should be boring](https://www.ncameron.org/blog/rust-2018/) by nrc.
+* [Don’t be the new Haskell](https://medium.com/@tibotz/rust-2018-dont-be-the-new-haskell-a383dbd74481) by /u/tibodelor.
+* [Improving how we improve Rust in 2018](http://www.jonathanturner.org/2018/01/rust2018-and-data.html) by jonathandturner.
+* [Three humble paper cuts](https://gist.github.com/cessen/394829673855e56157f63b4447f91e67) by cessen.
+* [What Rust needs in 2018 to succeed](https://llogiq.github.io/2018/01/09/rust.html) by llogiq.
+* [What I want changed for Rust to help Way Cooler](http://way-cooler.org/blog/2018/01/09/way-cooler-turns-two.html) by Timidger.
+* [Back to the roots](https://www.reddit.com/r/rust/comments/7p6n90/rust2018_back_to_the_roots/) by /u/0b_0101_001_1010.
+* [Looking back and looking forward](https://gist.github.com/est31/c063704716b6880fd74ce2ba11b11298) by est31.
+* [My wish list for 2018](http://www.mmrath.com/post/rust-my-wish-list-for-2018/) by mmrath.
+* [Looking in on Rust in 2018](https://kasma1990.gitlab.io/2018/01/07/looking-in-on-rust-in-2018/) by KasMA1990.
+* [The new wave of Rust](https://quietmisdreavus.net/code/2018/01/07/the-new-wave-of-rust/) by QuietMisdreavus.
+* [New faces for our lovely bots](https://lukaskalbertodt.github.io/2018/01/07/new-faces-for-bots-rust2018.html) by LukasKalbertodt.
+* [Better Debug derive](https://www.reddit.com/r/rust/comments/7p4imw/rust2018_wishpost_better_debug_derive/) by lokathor.
+* [Machine learning perspective](https://www.reddit.com/r/rust/comments/7p6rpw/rust_2018_machine_learning_perspective/) by /u/osamc.
+* [Rust 2018](http://www.suspectsemantics.com/blog/2018/01/07/rust-2018/) by AndrewBrinker.
+* [Goals and directions for Rust in 2018](http://www.wezm.net/technical/2018/01/goals-directions-rust-2018/) by wezm.
+
+Number: 217  Date: 2018-01-16 
+
+* [Announcement: a new Release Team, and new leadership for the Infrastructure Team](https://internals.rust-lang.org/t/announcement-a-new-release-team-and-new-leadership-for-the-infrastructure-team/6562).
+* [Clap's new year's weight loss program with cargo-bloat](https://clap.rs/2018/01/09/new-years-weight-loss/).
+* [What’s Tokio and async IO all about](https://manishearth.github.io/blog/2018/01/10/whats-tokio-and-async-io-all-about/)?
+* [Writing complex macros in Rust: Reverse Polish notation](https://rreverser.com/writing-complex-macros-in-rust/).
+* [About the undefined behavior](https://vorner.github.io/undefined.html).
+* [Benchmarking in stable Rust with criterion.rs](https://bheisler.github.io/post/benchmarking-with-criterion-rs/).
+* [Running Rust in browser: A tutorial with Turtle](https://varblog.org/blog/2018/01/08/rust-and-webassembly-with-turtle/).
+* [Debugging Rust programs with lldb on MacOS](https://bryce.fisher-fleig.org/blog/debugging-rust-programs-with-lldb/index.html).
+* [A year with Rust & game dev](http://druerridge.com/?p=536).
+* [Rust Enhanced: 2017 in review and what's coming in 2018](https://jason-williams.co.uk/rust-enhanced-reaches-50k-downloads/). Rust Enhanced is the official Sublime Text 3 package for Rust.
+* [This week in Rust docs 88](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-88).
+* [podcast] [New Rustacean: Interview – Diesel 1.0, with Sean Griffin, part 1](https://www.patreon.com/newrustacean). On growing Diesel's community, self-imposed technical challenges, and some of the ways Diesel has contributed to the Rust ecosystem.
+* [podcast] [Rusty Spike Podcast - episode 14](https://rusty-spike.blubrry.net/2018/01/11/episode-14-jan-10-2018/). #Rust2018 blogging, Rust 1.23, Rust 1.24, Diesel 1.0, cargo-bloat, Programming Rust O’Reilly book, mrustc, May, the final impl period, and the Rust year in review.
+## #Rust2018
+Find all #Rust2018 posts at [Read Rust](http://readrust.net/rust2018/).
+
+Number: 218  Date: 2018-01-23 
+
+* [Welcome kodraus and withoutboats as full Libs Team members](https://internals.rust-lang.org/t/welcome-kodraus-and-withoutboats-as-full-libs-team-members/6582)!
+* [Retooling the Rust Libs Team team for 2018](https://aturon.github.io/blog/2018/01/16/libs-mission/).
+* [Rust by Example is now part of official Rust docs (nightly)](https://doc.rust-lang.org/nightly/rust-by-example/).
+* [Redox crash challenge](https://github.com/redox-os/redox/issues/1136).
+* [Introduction to lyon: 2D vector graphics rendering on the GPU in Rust](https://nical.github.io/posts/lyon-intro.html).
+* [Brave new I/O: A new approach to I/O in embedded contexts](http://blog.japaric.io/brave-new-io/).
+* [Oxidizing Source Maps with Rust and WebAssembly](https://hacks.mozilla.org/2018/01/oxidizing-source-maps-with-rust-and-webassembly/).
+* [Using Capabilities to design safer, more expressive APIs](http://zsck.co/writing/capability-based-apis.html).
+* [State machines in a Rust game](https://dev.to/mindflavor/lets-build-zork-using-rust-1opm).
+* [Ref patterns, destructuring, and invisible borrows](https://medium.com/@robertgrosse/ref-patterns-destructuring-and-invisible-borrows-2f8ae6902656).
+* [WebRender capture infrastructure](https://kvark.github.io/webrender/debug/ron/2018/01/23/wr-capture-infra.html).
+* [Why is Rust difficult](https://vorner.github.io/difficult.html)?
+* [This week in Rust docs 89](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-89).
+* [podcast] [The Changelog: Building a secure operating system with Rust](https://changelog.com/podcast/280).
+* [podcast] [New Rustacean: Interview – Diesel 1.0, with Sean Griffin, part 2](http://www.newrustacean.com/show_notes/interview/diesel_1_0/part_2/). Getting Diesel to 1.0, writing docs and exposing problems with the API, improving Diesel in the future, and thinking about API design for open source libraries in general.
+* [podcast] [Rusty Spike Podcast - episode 15](https://rusty-spike.blubrry.net/2018/01/18/episode-15-jan-17-2018/). Atom, Programming Rust, more books, Rust governance, http2 support, #rust2018 and more.
+## #Rust2018
+Find all #Rust2018 posts at [Read Rust](http://readrust.net/rust2018/).
+
+Number: 219  Date: 2018-01-30 
+
+* [Async/Await I: Self-referential structs](https://boats.gitlab.io/blog/post/2018-01-25-async-i-self-referential-structs/).
+* [Seamless Rust integration into JavaScript with Parcel](https://medium.com/@devongovett/parcel-v1-5-0-released-source-maps-webassembly-rust-and-more-3a6385e43b95).
+* [Rust lifetimes for the uninitialised](http://asquera.de/blog/2018-01-29/rust-lifetimes-for-the-uninitialised/).
+* [Unfolding a Stream of paginated items](http://xion.io/post/code/rust-unfold-pagination.html). How to use the `Stream` interface and functions from futures crate.
+* [opinion] [Maybe it's time for a crates team](https://beyermatthias.de/blog/2018/01/31/maybe-its-time-for-a-crates-team/).
+* [This week in Rust docs 90](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-90).
+* [podcast] [Rusty Spike Podcast - episode 16](https://rusty-spike.blubrry.net/2018/01/25/episode-16-jan-24-2018/). Parcel, Mozilla, Lyon, a Redox interview and hackfest, Mercurial, and HackerRank.
+## #Rust2018
+Find all #Rust2018 posts at [Read Rust](http://readrust.net/rust2018/).
+
+Number: 220  Date: 2018-02-06 
+
+* [The 2018 Rust event lineup](https://blog.rust-lang.org/2018/01/31/The-2018-Rust-Event-Lineup.html).
+* [A vision for portability in Rust](https://aturon.github.io/2018/02/06/portability-vision/).
+* [Async/await II: Narrowing the scope of the problem](https://boats.gitlab.io/blog/post/2018-01-30-async-ii-narrowing-the-scope/).
+* [Async/await III: Moving forward with something shippable](https://boats.gitlab.io/blog/post/2018-01-30-async-iii-moving-forward/).
+* [In Rust, ordinary vectors are values](http://smallcultfollowing.com/babysteps/blog/2018/02/01/in-rust-ordinary-vectors-are-values/).
+* [Make your own make (build system)](https://matklad.github.io/2018/01/03/make-your-own-make.html).
+* [Introduction to procedural macros](https://tinkering.xyz/posts/introduction-to-proc-macros/).
+* [Sharing for a Lifetime](https://www.ralfj.de/blog/2018/01/31/sharing-for-a-lifetime.html). Some thoughts on how interior mutability fundamentally affects how we have to think about shared references, and how that relates to the private invariants maintained by a type.
+* [Writing a command-line program in Rust](https://people.gnome.org/~federico/blog/writing-a-command-line-program-in-rust.html).
+* [Writing eBPF tracing tools in Rust](https://jvns.ca/blog/2018/02/05/rust-bcc/).
+* [Compiling to eBPF from Rust](https://unhandledexpression.com/2018/02/02/poc-compiling-to-ebpf-from-rust/).
+* [Experimenting with the new I/O framework for embedded systems](http://pramode.in/2018/01/31/ti-launchpad-with-rust-new-io/).
+* [These weeks in dev-tools 3](https://www.ncameron.org/blog/these-weeks-in-dev-tools-issue-3/).
+* [This week in Rust docs 91](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-91).
+* [podcast] [New Rustacean: e022 – `Send` and `Sync`: The “marker” traits Rust uses for safe concurrency](http://www.newrustacean.com/show_notes/e022/)
+* [podcast] [Rusty Spike Podcast - episode 17](https://rusty-spike.blubrry.net/2018/02/01/episode-17-jan-31-2018/). Awards, 2018 roadmap RFC, 2018 conferences, and KubOS.
+
+Number: 221  Date: 2018-02-13 
+
+* The community team is trying to improve outreach to meetup organisers. Please fill out their [call for contact info](https://docs.google.com/forms/d/e/1FAIpQLSf52YXGhqBaHtCXtVna4iHYMK7IQaTqUW6V-ztsZC8C2TBInQ/viewform) if you are running or used to run a meetup.
+* [Closing out an incredible week in Rust](https://aturon.github.io/2018/02/09/amazing-week/).
+* [Maximally minimal specialization: always applicable impls](http://smallcultfollowing.com/babysteps/blog/2018/02/09/maximally-minimal-specialization-always-applicable-impls/).
+* [Announcing the 2018 domain Working Groups](https://internals.rust-lang.org/t/announcing-the-2018-domain-working-groups/6737).
+* [Async/await IV: An even better proposal](https://boats.gitlab.io/blog/post/2018-02-07-async-iv-an-even-better-proposal/).
+* [Async/await V: Getting back to the futures](https://boats.gitlab.io/blog/post/2018-02-08-async-v-getting-back-to-the-futures/).
+* [How Rust is Tilde’s competitive advantage](https://www.rust-lang.org/pdfs/Rust-Tilde-Whitepaper.pdf).
+* [Guitar effects in Rust](http://rickyhan.com/jekyll/update/2018/02/06/rust-guitar-pedal-effects-dsp.html).
+* [Rust embedded: Memory safe DMA transfers](http://blog.japaric.io/safe-dma/).
+* [ripgrep 0.8.0 released: Configuration files, compressed file search, and true colors](https://github.com/BurntSushi/ripgrep/releases/tag/0.8.0).
+* [Tokio reform and the road to 0.2](https://tokio.rs/blog/2018-02-tokio-reform-shipped/).
+* [Introducing a wee allocator for WebAssembly](http://fitzgeraldnick.com/2018/02/09/wee-alloc.html).
+* [RLSL (Rust -> SPIR-V compiler) progress report](https://maikklein.github.io/rlsl-progress-report/).
+* [This week in Rust docs 92](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-92).
+* [podcast] [Rusty Spike Podcast - episode 18](https://rusty-spike.blubrry.net/2018/02/08/episode-18-feb-7-2018/). Reddit, a whitepaper, an academic paper, FOSDEM (and the lines), and AV1.
+* [podcast] [New Rustacean: Crates you should know: Serde](http://www.newrustacean.com/show_notes/cysk/serde/).
+* [RustFest 2018](https://blog.rustfest.eu/next-stop-paris). 26 May - 27 May 2018 in Paris.
+
+Number: 222  Date: 2018-02-20 
+
+* 🎈🎉 [Announcing Rust 1.24](https://blog.rust-lang.org/2018/02/15/Rust-1.24.html). 🎉🎈
+* [Rayon 1.0 is released](https://github.com/rayon-rs/rayon).
+* [Initial support for Rust has landed in quicktype](https://github.com/quicktype/quicktype/pull/512). quicktype generates types and converters from JSON.
+* [Announcement: Rust team structure revamp](https://internals.rust-lang.org/t/rust-team-structure-revamp/6776).
+* [Embedded Rust: Zero cost stack overflow protection for ARM Cortex-M devices](http://blog.japaric.io/stack-overflow-protection/).
+* [Borrow cycles in Rust: arenas v.s. drop-checking](https://exyr.org/2018/rust-arenas-vs-dropck/).
+* [Porting Rust to WebAssembly](https://udoprog.github.io/rust/2018-02-19/porting-rust-to-wasm.html).
+* [Mutation testing Rust in earnest](https://llogiq.github.io/2018/02/14/mutagen.html).
+* [“The expressive C++17 coding challenge (in Rust)” revisited](http://words.steveklabnik.com/the-expressive-c-17-coding-challenge-in-rust-revisited).
+* [Write a plugin system and script your app in Rust](http://phaazon.net/blog/spectra_plugins).
+* [Sorting in Rust: selection, insertion, and counting sort](https://medium.com/@spyr1014/sorting-in-rust-selection-insertion-and-counting-sort-2c4d3575e364).
+* [Learning Rust: A small set of pitfalls a novice might encounter, and how to avoid them](https://eno.space/blog/2018/02/Ferrous-oxide-for-jaguars-and-incremented-crocodiles).
+* [This week in Rust docs 93](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-93).
+* [podcast] [Rusty Spike Podcast - episode 19](https://rusty-spike.blubrry.net/2018/02/15/episode-19-feb-14-2018/). new teams, humble bundle, SIMD, being special, quicktype, and deps.rs.
+
+Number: 223  Date: 2018-02-27 
+
+* [Announcing the Embedded Devices Working Group](https://internals.rust-lang.org/t/announcing-the-embedded-devices-working-group/6839).
+* [Announcing stdweb 0.4 - export arbitrary functions to JavaScript](https://www.reddit.com/r/rust/comments/7z8imh/announcing_stdweb_04_now_with_support_for_parcel/).
+* [Speed without wizardry](http://fitzgeraldnick.com/2018/02/26/speed-without-wizardry.html). Rust + WebAssembly and performance.
+* [Programming an ARM microcontroller in Rust at four different levels of abstraction](http://pramode.in/2018/02/20/programming-a-microcontroller-in-rust-at-four-levels-of-abstraction/).
+* [Should you Rust in embedded yet](https://kazlauskas.me/entries/rust-embedded-ready.html)?
+* [Reasoning with types in Rust](https://aaronweiss.us/posts/2018-02-26-reasoning-with-types-in-rust.html).
+* [Typestates in Rust](https://yoric.github.io/post/rust-typestate/).
+* [Discovery: Discover the world of microcontrollers through Rust! - 2018 edition](https://japaric.github.io/discovery/).
+* [Oxidizing Fedora: Try Rust and its applications in Fedora 27](https://fedoramagazine.org/oxidizing-fedora-try-rust-applications-today/).
+* [Debian: Rust architecture status](https://lists.alioth.debian.org/pipermail/pkg-rust-maintainers/2018-February/001215.html).
+* [RustConf CFP is now open. Deadline is 13 April](https://cfp.rustconf.com/events/rustconf-2018/).
+* [RustFest CFP is now open. Deadline is 17 March](https://cfp.rustfest.eu/events/rustfest-paris).
+* [This week in Rust docs 94](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-94).
+* [podcast] [Rusty Spike Podcast - episode 20](https://rusty-spike.blubrry.net/2018/02/22/episode-20-feb-21-2018/). Rust 1.24, Rayon, Facebook, Fedora, Snips, and benchmarks.
+
+Number: 224  Date: 2018-03-06 
+
+* 🎈🎉 [Announcing Rust 1.24.1](https://blog.rust-lang.org/2018/03/01/Rust-1.24.1.html). 🎉🎈
+* [Announcing the CLI working group](https://internals.rust-lang.org/t/announcing-the-cli-working-group/6872).
+* [Come join the Rust and WebAssembly working group](http://fitzgeraldnick.com/2018/02/27/wasm-domain-working-group.html).
+* [Why Rust has macros](https://kasma1990.gitlab.io/2018/03/04/why-rust-has-macros/).
+* [Writing a microservice in Rust](http://www.goldsborough.me/rust/web/tutorial/2018/01/20/17-01-11-writing_a_microservice_in_rust/).
+* [Futures 0.2 is nearing release](https://aturon.github.io/2018/02/27/futures-0-2-RC/).
+* [Writing your first compiler: Making a Brainfuck to C compiler in Rust](https://medium.com/@CanHasCommunism/making-a-brainf-ck-to-c-compiler-in-rust-10f0c01a282d).
+* [Stopping a Rust worker](https://matklad.github.io/2018/03/02/stopping-a-rust-worker.html).
+* [Serializing awkward data with Serde](http://zork.net/~st/jottings/Serializing_awkward_data_with_serde.html).
+* [An introduction to writing platform agnostic drivers in Rust using the MCP3008 as an example](http://pramode.in/2018/02/24/an-introduction-to-writing-embedded-hal-based-drivers-in-rust/).
+* [Opportunistic mutations for the mutagen - a Rust mutation testing framework](https://llogiq.github.io/2018/03/03/opportune.html).
+* [This week in Rust docs 95](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-95).
+* [podcast] [New Rustacean: Rust 1.24](http://www.newrustacean.com/show_notes/news/rust_1_24/). Performance wins, incremental compilation, and the Rust 2018 Roadmap and Epoch.
+* [podcast] [Rusty Spike Podcast - episode 21](https://rusty-spike.blubrry.net/2018/03/01/episode-21-feb-28-2018/). SIMD, WebAssembly for performance, the embedded working group, the Rust+WebAssembly working group, and the return of the Servo newsletter.
+
+Number: 225  Date: 2018-03-13 
+
+* [Rust's 2018 roadmap](https://blog.rust-lang.org/2018/03/12/roadmap.html).
+* [Rust is the most loved language for 3 years in a row in Stack Overflow Developer Survey](https://insights.stackoverflow.com/survey/2018/#most-loved-dreaded-and-wanted).
+* [Writing an OS in pure Rust](https://os.phil-opp.com/news/2018-03-09-pure-rust/).
+* [Announcing the Tokio runtime](https://tokio.rs/blog/2018-03-tokio-runtime/).
+* [Redefining failure: Review of failure crate](https://epage.github.io/blog/2018/03/redefining-failure/).
+* [Announcing Rust Compiler Performance Working Group](https://internals.rust-lang.org/t/rust-compiler-performance-working-group/6934).
+* [Announcing Rust Portability Working Group](https://internals.rust-lang.org/t/rust-needs-to-run-and-be-easy-to-use-on-every-platform/6935).
+* [Snips open sources Snips NLU - a Natural Language Understanding service written in Rust](https://medium.com/snips-ai/snips-nlu-is-an-open-source-private-by-design-alternative-to-dialogflow-amazon-lex-and-other-nlu-a95dbe16f4a1).
+* [Announcing relibc: A libc implementation in Rust](https://github.com/redox-os/relibc).
+* [Exploring function overloading](http://casualhacks.net/blog/2018-03-10/exploring-function-overloading/).
+* [Coping with mutable state in multiple threads with Rust](https://medium.com/@KevinHoffman/coping-with-mutable-state-in-multiple-threads-with-rust-9059c83b6c01).
+* [Crashing a Rust Hyper server with a denial of service attack](https://klausi.github.io/rustnish/2018/03/11/crashing-a-rust-hyper-server-with-a-denial-of-service-attack.html).
+* [This week in Rust docs 96](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-96).
+* [podcast] [Rusty Spike Podcast - episode 22](https://rusty-spike.blubrry.net/2018/03/08/episode-22-mar-7-2018/). Rust 1.24.1, the 2018 roadmap, compile times, SIMD, and Pathfinder.
+
+Number: 226  Date: 2018-03-20 
+
+* [Making WebAssembly better for Rust & for all languages](https://hacks.mozilla.org/2018/03/making-webassembly-better-for-rust-for-all-languages/).
+* [Building a fast Electron app with Rust](https://keminglabs.com/blog/building-a-fast-electron-app-with-rust/).
+* [Statuses of unstable standard library features](https://internals.rust-lang.org/t/survey-of-unstable-standard-library-features/7075).
+* [Building a DNS server in Rust](https://github.com/EmilHernvall/dnsguide).
+* [Type-directed metaprogramming in Rust](http://willcrichton.net/notes/type-directed-metaprogramming-in-rust/).
+* [Multicasting in Rust](https://bluejekyll.github.io/blog/rust/2018/03/18/multicasting-in-rust.html).
+* Mutating Rust: [Pattern boldness](https://llogiq.github.io/2018/03/13/patterns.html) and [deciding if two types are equal](https://llogiq.github.io/2018/03/15/types.html).
+* [kernel-roulette: An example Linux kernel module written in Rust](https://github.com/souvik1997/kernel-roulette).
+* [CLI Working Group newsletter 1](https://internals.rust-lang.org/t/cli-wg-newsletter-1/7061).
+* [The Embedded Working Group newsletter 1](https://internals.rust-lang.org/t/the-embedded-working-group-newsletter-1/7053).
+* [This week in Rust docs 97](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-97).
+* [podcast] [Rusty Spike Podcast - episode 23](https://rusty-spike.blubrry.net/2018/03/15/episode-23-march-14-2018/). Ember, the roadmap, Redmonk, IDEs, and MIRI.
+
+Number: 227  Date: 2018-03-27 
+
+* [Async/Await VI: 6 weeks of great progress](https://boats.gitlab.io/blog/post/2018-03-20-async-vi/).
+* [Python idioms in Rust](http://benjamincongdon.me/blog/2018/03/23/Python-Idioms-in-Rust/).
+* [Dora: Implementing a JIT-compiler with Rust](https://dinfuehr.github.io/blog/dora-implementing-a-jit-compiler-with-rust/).
+* [Atomics and memory ordering](https://vorner.github.io/2018/03/25/Atomics.html).
+* [Talks I'd love to see at RustConf](https://jvns.ca/blog/2018/03/24/rustconf-talks/).
+* [Designing a fast CLI join tool with rust](https://milancio42.github.io/blog/2018-03-22-rjoin/).
+* [Building a Restful CRUD API with Rust](https://medium.com/sean3z/building-a-restful-crud-api-with-rust-1867308352d8).
+* [Touring a fast, safe, and complete(ish) web service in Rust](https://brandur.org/rust-web).
+* [Putting bors on a performance improvement plan](https://aturon.github.io/2018/03/19/bors/).
+* [Mutation based testing & code coverage](https://llogiq.github.io/2018/03/25/cover.html).
+* [Redox OS 0.3.5 is released with a new network stack](https://github.com/redox-os/redox/releases/tag/0.3.5).
+* [Announcing the Ecosystem Working Group](https://users.rust-lang.org/t/announcing-the-ecosystem-working-group/16324).
+* [Rust 2018 All Hands is under way in Berlin](https://internals.rust-lang.org/t/rust-2018-all-hands/7141).
+* [This Week in Rust Docs 98](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-98).
+* [podcast] [Rusty Spike Podcast - episode 24](https://rusty-spike.blubrry.net/2018/03/22/episode-24-mar-21-2018/). Latin America, async/await, electron, and behind the scenes on Rust 2018.
+
+Number: 228  Date: 2018-04-03 
+
+* 🎈🎉 [Announcing Rust 1.25](https://blog.rust-lang.org/2018/03/29/Rust-1.25.html). 🎉🎈
+* [Tokio: New Timer implementation](https://tokio.rs/blog/2018-03-timers/).
+* [Refactoring some repetitive code to a Rust macro](https://people.gnome.org/~federico/blog/refactoring-some-repetitive-code-to-a-macro.html).
+* [History of the Rand crate](https://www.reddit.com/r/rust/comments/87qy40/history_of_the_rand_crate/).
+* [HTTP upgrades with hyper](http://seanmonstar.com/post/172531530657/http-upgrades-with-hyper).
+* [Porting an academic C++ library to Rust to do analysis on Doom maps](https://eev.ee/blog/2018/03/30/a-geometric-rust-adventure/).
+* [Building tiny Rust binaries for embedded Linux](https://jamesmunns.com/update/2018/04/01/tinyrocket.html).
+* [Speeding up dwarfdump with Rust](https://robert.ocallahan.org/2018/03/speeding-up-dwarfdump-with-rust.html).
+* [Analysing crates.io data for top dependencies](https://tirkarthi.github.io/rust/2018/03/30/analyzing-crates-data.html).
+* [Rust-webapp-starter: A template for Actix-web and Vue.js](https://github.com/OUISRC/Rust-webapp-starter)
+* [This week in Rust docs 99](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-99).
+* [The Embedded Working Group Newsletter 2](https://internals.rust-lang.org/t/the-embedded-working-group-newsletter-2/7176).
+* [podcast] [New Rustacean: Rust 1.25](https://newrustacean.com/show_notes/news/rust_1_25/). Paths and matches and SIMD, cargo new changes, and tons of community-driven learning materials.
+
+Number: 229  Date: 2018-04-10 
+
+* [Async & await in Rust: a full proposal](https://boats.gitlab.io/blog/post/2018-04-06-async-await-final/).
+* [JavaScript to Rust and back again: A wasm-bindgen tale](https://hacks.mozilla.org/2018/04/javascript-to-rust-and-back-again-a-wasm-bindgen-tale/).
+* [A formal look at pinning](https://www.ralfj.de/blog/2018/04/05/a-formal-look-at-pinning.html).
+* [The dark side of ergonomics](https://vorner.github.io/2018/04/08/Dark-side-of-ergonomics.html).
+* [Announcing the Formal Verification Working Group](https://internals.rust-lang.org/t/announcing-the-formal-verification-working-group/7240).
+* [Increasing Rust’s reach 2018](https://blog.rust-lang.org/2018/04/02/Increasing-Rusts-Reach-2018.html).
+* [The state of game development in Rust](http://www.davideaversa.it/2018/02/state-game-development-rust/).
+* [Sponza: A demo of a Rust game engine running with WASM in the browser](https://edwin0cheng.github.io/unrust/demo/sponza/).
+* [Futures 0.2 is here](https://aturon.github.io/2018/04/06/futures2/).
+* [toml 0.4.6 is released which includes a `toml!` macro to easily build `toml::Value` objects](https://docs.rs/toml/0.4/toml/macro.toml.html).
+* [Announcing Tower — a library for writing robust network services with Rust](https://medium.com/@carllerche/announcing-tower-a-library-for-writing-robust-network-services-with-rust-67273f052c40).
+* [Bringing Vulkan everywhere](http://gfx-rs.github.io/2018/04/09/vulkan-portability.html) — an update on gfx-rs portability initiative.
+* [Improving GStreamer performance on a high number of network streams by sharing threads between elements with Rust’s tokio crate](https://coaxion.net/blog/2018/04/improving-gstreamer-performance-on-a-high-number-of-network-streams-by-sharing-threads-between-elements-with-rusts-tokio-crate/).
+* [Writing a recursive ascent parser by hand](https://www.abubalay.com/blog/2018/04/08/recursive-ascent).
+* [Rust in ten slides](https://steveklabnik.github.io/rust-in-ten-slides/).
+* [A gentle introduction to Rust](https://stevedonovan.github.io/rust-gentle-intro/).
+* [This week in Rust docs 100](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-100).
+* [This week in Rust and WebAssembly 1](https://rustwasm.github.io/2018/04/05/welcome-to-this-week-in-rust.html).
+### From Rust All Hands in Berlin
+* [The Rust team All Hands in Berlin: a recap](https://blog.rust-lang.org/2018/04/06/all-hands.html).
+* [Sound and ergonomic specialization for Rust](https://aturon.github.io/2018/04/05/sound-specialization/).
+* [Cargo, Xargo, and Rustup](https://aturon.github.io/2018/04/06/rustup-xargo/).
+* [Custom tasks in Cargo](https://aturon.github.io/2018/04/05/workflows/).
+
+Number: 230  Date: 2018-04-17 
+
+* [Redox Summer of Code](https://www.redox-os.org/rsoc/).
+* [Writing An NES Emulator with Rust and WebAssembly](https://medium.com/@bokuweb17/writing-an-nes-emulator-with-rust-and-webassembly-d64de101c49d).
+* [Down a rusty rabbit hole](https://manishearth.github.io/blog/2018/04/12/down-a-rusty-rabbit-hole/). Discovering a series of quirks of the Rust compiler/language.
+* [The case for deadlines in timeout-centric APIs](https://gist.github.com/alkis/9510a840f1965185ab0a02cb59761dd8).
+* [Rust pattern: Rooting an Rc handle](http://smallcultfollowing.com/babysteps/blog/2018/04/16/rust-pattern-rooting-an-rc-handle/).
+* [Conway's Game of Life: A tutorial on implementing a game in Rust and WebAssembly](https://rust-lang-nursery.github.io/rust-wasm/game-of-life/introduction.html).
+* [Safe intrusive collections with pinning](https://www.ralfj.de/blog/2018/04/10/safe-intrusive-collections-with-pinning.html).
+* [Rust memory safety revolution: Why, what, and how for complete beginners](https://anixe.pl/content/news/rust_memory_safety_revolution).
+* [A useful feature few Rust programmers know about](http://rickyhan.com/jekyll/update/2018/04/16/the-best-kept-secret-rust-feature.html). The `{:#?}` pretty-printer flag.
+* [Instance identity in C++ and Rust](https://jrvanwhy.github.io/instance-identity/).
+* [A shifty riddle: Why is `std::ops::Shl::shl` not equal to `<<`](https://llogiq.github.io/2018/04/11/shift.html)?
+* [Fearless Rust bloggers](https://users.rust-lang.org/t/fearless-rust-bloggers/16770). A list of blogs from past This Week in Rust issues.
+* Armstrong Publications released a Rust book [Step Ahead with Rust](https://www.armstrong-publications.com/product/step-ahead-with-rust/) for intermediate to advanced programmers.
+* [This week in Rust docs 101](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-101).
+* [The Embedded Working Group newsletter 3](https://internals.rust-lang.org/t/the-embedded-working-group-newsletter-3/7319).
+* [CLI Working Group newsletter 2](https://internals.rust-lang.org/t/cli-wg-newsletter-2/7309).
+* [IntelliJ Rust changelog 72](https://intellij-rust.github.io/2018/04/16/changelog-72.html). Now with support for macro expansion.
+* [podcast] [Rusty Spike Podcast - episode 25](https://rusty-spike.blubrry.net/2018/04/12/episode-25-apr-11-2018/). Rust Reach, the Rust all hands, webassembly.studio, more wasm tools, async/await, and GStreamer.
+### From Rust All Hands in Berlin
+* [Rust all-hands (dev-tools stuff)](https://www.ncameron.org/blog/rust-all-hands-dev-tools-stuff/).
+
+Number: 231  Date: 2018-04-24 
+
+* [Announcing cargo src (beta)](https://ncameron.org/blog/announcing-cargo-src-beta/).
+* [Hello `wasm-pack`](https://hacks.mozilla.org/2018/04/hello-wasm-pack/) - a tool for assembling and packaging Rust crates that targets WebAssembly.
+* [Dev-tools team: Goals for 2018](https://www.ncameron.org/blog/dev-tools-in-2018/).
+* [pdf] [Rust case study: Chucklefish taps Rust to bring safe concurrency to video games](https://www.rust-lang.org/pdfs/Rust-Chucklefish-Whitepaper.pdf).
+* [Facebook announces fastmod, a code refactoring tool written in Rust](https://twitter.com/fbOpenSource/status/987050395972255744).
+* [Reports from the Madrid Rust+GNOME Hackfest](https://wiki.gnome.org/Hackfests/Rust2018#Reports).
+* [GLib/GIO async operations and Rust futures + async/await](https://coaxion.net/blog/2018/04/glib-gio-async-operations-and-rust-futures-async-await/).
+* [Announcing the Network Services Working Group (WG-Net)](https://internals.rust-lang.org/t/announcing-the-network-services-working-group-wg-net/7354).
+* [Small WebAssembly binaries with Rust + Emscripten](https://kripken.github.io/blog/binaryen/2018/04/18/rust-emscripten.html).
+* [This week in Rust docs 102](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-102).
+* [podcast] [Rusty Spike Podcast - episode 26](https://rusty-spike.blubrry.net/2018/04/19/episode-26-apr-18-2018/). wasm-pack, SIMD, IntelliJ, VSCode, cargo src, hackfests, rustfmt, and redox.
+
+Number: 232  Date: 2018-05-01 
+
+* [regex 1.0 is released](https://github.com/rust-lang/regex/releases/tag/1.0.0).
+* [nperf: A sampling CPU profiler for Linux written in Rust from Nokia](https://github.com/nokia/nperf).
+* [How to speed up the Rust compiler in 2018](https://blog.mozilla.org/nnethercote/2018/04/30/how-to-speed-up-the-rust-compiler-in-2018/).
+* [Borrowing in async code](https://aturon.github.io/2018/04/24/async-borrowing/).
+* [An alias-based formulation of the borrow checker](http://smallcultfollowing.com/babysteps/blog/2018/04/27/an-alias-based-formulation-of-the-borrow-checker/).
+* [Writing an OS in Rust: Unit testing](https://os.phil-opp.com/unit-testing/).
+* [How does dynamic dispatch work in WebAssembly](http://fitzgeraldnick.com/2018/04/26/how-does-dynamic-dispatch-work-in-wasm.html)?
+* [Rust pattern: Precise closure capture clauses](http://smallcultfollowing.com/babysteps/blog/2018/04/24/rust-pattern-precise-closure-capture-clauses/).
+* [Embedded Rust experiments - Flipping some bits high on STM32VLDISCOVERY board](https://nercury.github.io/rust/embedded/experiments/2018/04/29/rust-embedded-01-discovery-vl-flipping-bits.html).
+* [Introducing Sentry for Rust](https://blog.sentry.io/2018/05/01/sentry-for-rust).
+* [Installing Rust offline](https://hatsunearu.github.io/2018/04/29/rust-offline/).
+* [This week in Rust docs 103](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-103).
+* [This week in Rust and WebAssembly 001](https://rustwasm.github.io/2018/04/21/this-week-in-rust-wasm-001.html).
+* [The Embedded Working Group newsletter 4](https://internals.rust-lang.org/t/the-embedded-working-group-newsletter-4/7414).
+* [CLI Working Group newsletter 3](https://internals.rust-lang.org/t/cli-wg-newsletter-3/7406).
+* [podcast] [Rusty Spike Podcast - episode 27](https://rusty-spike.blubrry.net/2018/04/26/episode-27-apr-25-2018/). Game development, GNOME, Facebook, and match-making.
+* [podcast] [New Rustacean: e023 – Traits deep dive, part 1](https://newrustacean.com/show_notes/e023/).
+
+Number: 233  Date: 2018-05-08 
+
+* [New Tokio release, now with filesystem support](https://tokio.rs/blog/2018-05-tokio-fs/).
+* [Encapsulating lifetime of the field](https://matklad.github.io/2018/05/04/encapsulating-lifetime-of-the-field.html).
+* [Rust in production at Figma](https://blog.figma.com/rust-in-production-at-figma-e10a0ec31929).
+* [How fast can we compile Rust hello world](http://www.jonathanturner.org/2018/05/how-fast-can-we-compile-rust-hello-world.html)?
+* [Refactoring Apache Arrow to use traits and generics](https://andygrove.io/2018/05/apache-arrow-traits-generics/).
+* [Introducing gtk-test - a framework to test GTK UI](http://gtk-rs.org/blog/2018/05/02/who-talked-about-testing.html).
+* [Introducing seiri — a music manager written in Rust](https://medium.com/@chyyran/introducing-seiri-a-music-manager-for-lots-of-music-990b464b3387).
+* [sudo_pair: A sudo plugin from Square that requires another human to approve and monitor privileged sudo sessions](https://github.com/square/sudo_pair).
+* [Announcing the codegen working group](https://internals.rust-lang.org/t/announcing-the-codegen-working-group/7434).
+* [This week in Rust docs 104](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-104).
+* [Networking WG newsletter 1](https://internals.rust-lang.org/t/networking-wg-newletter-1/7431).
+* [podcast] [Rusty Spike Podcast - episode 28](https://rusty-spike.blubrry.net/2018/05/03/episode-28-may-2-2018/). Figma, Sentry, Polysync, Nokia, Maryland, regex, compilers, and the borrow checker.
+
+Number: 234  Date: 2018-05-15 
+
+* 🎈🎉 [Announcing Rust 1.26](https://blog.rust-lang.org/2018/05/10/Rust-1.26.html). 🎉🎈
+* 🎈🎉 [Rust turns three](https://blog.rust-lang.org/2018/05/15/Rust-turns-three.html). 🎉🎈
+* [How Rust 1.26 more than tripled the speed of my code](http://troubles.md/posts/the-power-of-compilers/).
+* [Notes on impl Trait](https://www.reddit.com/r/rust/comments/8ik620/notes_on_impl_trait/).
+* [Entity-Component-System architecture for UI in Rust](https://raphlinus.github.io/personal/2018/05/08/ecs-ui.html).
+* [Performance experiments with matrix multiplication](https://vorner.github.io/2018/05/12/Mat-perf.html).
+* [Cortex-M library development now possible on beta and the path towards stable embedded Rust](https://users.rust-lang.org/t/cortex-m-library-development-now-possible-on-beta-and-the-path-towards-stable-embedded-rust/17420).
+* [nom 4.0 released: faster, safer, simpler parsers](http://unhandledexpression.com/general/2018/05/14/nom-4-0-faster-safer-simpler-parsers.html).
+* [This week in Rust docs 105](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-105).
+* [This week in Rust and WebAssembly 2](https://rustwasm.github.io/2018/05/14/this-week-in-rust-wasm-002.html).
+* [These weeks in dev tools issue 4](https://www.ncameron.org/blog/these-weeks-in-dev-tools-issue-4/).
+* [podcast] [New Rustacean: Rust 1.26](https://newrustacean.com/show_notes/e023/). impl trait, match on references, Results from main, and more. A good way to mark three years since Rust 1.0!
+
+Number: 235  Date: 2018-05-22 
+
+* [The Rust compiler is getting faster](https://blog.mozilla.org/nnethercote/2018/05/17/the-rust-compiler-is-getting-faster/).
+* [Rand 0.5.0 released with quite significant changes over 0.4](https://www.reddit.com/r/rust/comments/8l95zk/rand_050_released/).
+* [Cannoli: A Python compiler written entirely in Rust](https://github.com/joncatanio/cannoli).
+* [Auto reloading development web servers with systemfd/listenfd](https://www.reddit.com/r/rust/comments/8kpea2/ann_auto_reloading_development_web_servers_with/).
+* [Migrating to Actix Web from Rocket for stability](https://nbsoftsolutions.com/blog/migrating-to-actix-web-from-rocket-for-stability).
+* [Improving SmallVec's speed by 60% and why that shouldn't matter to you](http://troubles.md/posts/improving-smallvec/).
+* [Swapping and dropping to accelerate Rust in a benchmark](https://barrielle.cedeela.fr/research_page/dropping-drops.html).
+* [Building a Datalog engine in under 300 lines of Rust](https://github.com/frankmcsherry/blog/blob/master/posts/2018-05-19.md).
+* [Porting Rust benchmarks to Criterion](https://llogiq.github.io/2018/05/18/criterion.html).
+* [Compile time prevention of SQL-injections in Rust](https://polyfloyd.net/post/compile-time-prevention-of-sql-injections/).
+* [This week in Rust docs 106](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-106).
+* [The Embedded Working Group newsletter 5](https://internals.rust-lang.org/t/the-embedded-working-group-newsletter-5/7536).
+* [podcast] [CoRecursive w/ Adam Bell - 013](https://corecursive.com/013-rust-and-with-jim-blandy). Rust and bitter C++ developers with Jim Blandy, one of the authors of Programming Rust.
+* [podcast] [Rusty Spike Podcast - episode 29](https://rusty-spike.blubrry.net/2018/05/17/episode-29-may-16-2018/). Square, Amazon, the 1.26 release, Cloudflare, Rust’s birthday, and three-fold improvements.
+
+Number: 236  Date: 2018-05-29 
+
+* 🎈🎉 [Announcing Rust 1.26.1](https://blog.rust-lang.org/2018/05/29/Rust-1.26.1.html). 🎉🎈
+* [Exploring Rust fat pointers](https://iandouglasscott.com/2018/05/28/exploring-rust-fat-pointers/).
+* [Typed key pattern](https://matklad.github.io/2018/05/24/typed-key-pattern.html). A pattern for extracting values from a weakly typed map.
+* [aturon.log: listening and trust, part 1](https://aturon.github.io/2018/05/25/listening-part-1/). Thoughts on controversies from past week.
+* [Clippy is removing the `#![plugin(clippy)]` API in favour of `cargo clippy`](https://github.com/rust-lang-nursery/rust-clippy/pull/2783).
+* [Fuzz testing in Rust with Cargo-fuzz](https://medium.com/@seasoned_sw/fuzz-testing-in-rust-with-cargo-fuzz-13b89feecc30).
+* [Wicked fast web servers in Rust - An introduction to writing a simple web server using Thruster](https://medium.com/@MertzAlertz/wicked-fast-web-servers-in-rust-4947688426bc).
+* [Bobbin SDK: Richer hardware abstractions for embedded systems programming](http://www.bobbin.io/blog/post/bobbin_sdk_richer_hardware/).
+* [video] [RustFest Paris 2018 recordings](https://www.youtube.com/watch?v=23lRkdDXqY0&list=PL85XCvVPmGQgdqz9kz6qH3SI_hp7Zb4s1).
+* [podcast] [Rusty Spike Podcast - episode 30](https://rusty-spike.blubrry.net/2018/05/24/episode-30-may-23-2018/). Compile times, Aaron’s new quest, books, logic programming, JetBrains, and RustConf.
+### GSoC Projects
+* [Nebulet - Booting up](http://lsneff.me/nebulet-booting-up/). Nebulet is a microkernel that executes WebAssembly. See also: [Why Nebulet](http://lsneff.me/why-nebulet/)?
+* [Cargo-ebuild - GSoC week 1 report](https://gibix.github.io/2018/05/20/gsoc-week-1-report.html).
+### RSoC Projects
+* [Porting tokio-rs to redox](https://www.redox-os.org/news/rsoc-porting-tokio-1/).
+* [Implementing a FAT32 Filesystem in Redox](https://www.redox-os.org/news/rsoc-fat32-1/).
+
+Number: 237  Date: 2018-06-05 
+
+* 🎈🎉 [Announcing Rust 1.26.2](https://blog.rust-lang.org/2018/06/05/Rust-1.26.2.html). 🎉🎈
+* [How to speed up the Rust compiler some more in 2018](https://blog.mozilla.org/nnethercote/2018/06/05/how-to-speed-up-the-rust-compiler-some-more-in-2018/).
+* [The future of Clippy (the Rust linter)](https://manishearth.github.io/blog/2018/06/05/the-future-of-clippy-the-rust-linter/).
+* [Async methods I: generic associated types](https://boats.gitlab.io/blog/post/async-methods-i/).
+* [Async methods II: object safety](https://boats.gitlab.io/blog/post/async-methods-ii/).
+* [Avoiding the pyramid of doom](https://www.reddit.com/r/rust/comments/8n4o5q/avoiding_the_pyramid_of_doom/).
+* [The Rust way of OS development](https://phil-opp.github.io/talk-konstanz-may-2018/).
+* [The secret life of Cows](https://deterministic.space/secret-life-of-cows.html).
+* [The state of Gotham](https://gotham.rs/blog/2018/05/31/the-state-of-gotham.html).
+* [Optimising path tracing with SIMD](https://bitshifter.github.io/blog/2018/06/04/simd-path-tracing/).
+* [Writing a simple web service in Rust with actix-web](https://danielwelch.github.io/rust-web-service.html).
+* [Newtype index pattern](https://matklad.github.io/2018/06/03/newtype-index-pattern.html).
+* [Tricking the HashMap](https://idubrov.github.io/rust/2018/06/01/tricking-the-hashmap.html).
+* [The Rust language and special cases](https://blog.infinitenegativeutility.com/2018/6/the-rust-language-and-special-cases).
+* [aturon.log: listening and trust, part 2](https://aturon.github.io/2018/06/02/listening-part-2/).
+* [Introducing feL4: Rust programs for the seL4 microkernel](https://www.reddit.com/r/rust/comments/8oqppz/introducing_fel4_rust_programs_for_the_sel4/).
+* [hyper v0.12 is released](http://seanmonstar.com/post/174480374517/hyper-v012).
+* [This week in Rust docs 107](https://guillaumegomez.github.io/this-week-in-rust-docs/blog/this-week-in-rust-docs-107).
+* [This week in Rust and WebAssembly 3](https://rustwasm.github.io/2018/06/04/this-week-in-rust-wasm-003.html).
+* [podcast] [New Rustacean: Crates you should know: wasm](https://newrustacean.com/show_notes/cysk/wasm/index.html). wasm intro, wasm-bindgen, and wasm-pack.
+* [podcast] [Rusty Spike Podcast - episode 31](https://rusty-spike.blubrry.net/2018/05/31/episode-31-may-30-2018/). 1.26.1 release, RustFest videos, Rust reach, RustRush 2018, and a bit of behind the scenes look at running Rust.
+
+Number: 238  Date: 2018-06-12 
+
+* [Understanding the difference between `Box<Trait>`, `&Trait`, `impl Trait`, and `dyn Trait`](https://joshleeb.com/posts/rust-traits-and-trait-objects/).
+* [varkor joins the Compiler Team](https://internals.rust-lang.org/t/please-welcome-varkor-to-the-compiler-team/7716)!
+* [First screenshot of Dota2 running on gfx-portabilty with Metal backend](https://www.reddit.com/r/rust/comments/8pmniu/first_screenshot_of_dota2_running_on/).
+* [Actix – an actor framework for Rust](https://simplabs.com/blog/2018/06/11/actix.html).
+* [Migrating to Actix from Rocket](https://noyez.gitlab.io/post/2018-06-11-rocket-to-actix/).
+* [A Rust-based unikernel: First version of a Rust-based libOS](https://hermitcore.org/2018/06/06/A-Rust-based-Unikernel/).
+* [Where do Rust threads come from](http://www.squidarth.com/rc/rust/concurrency/2018/06/09/rust-threads-detach.html)?
+* [To do a Rust GUI](https://www.vandenoever.info/blog/2018/06/09/to-do-a-rust-gui.html).
+* [Integrating QML and Rust: Creating a QMetaObject at compile time](https://woboq.com/blog/qmetaobject-from-rust.html).
+* [crates.rs: An alternative to crates.io](https://crates.rs/).
+* [nphysics: A Physics engine in Rust now has 3D demos running in modern browsers](http://demo.nphysics.org/).
+* [podcast] [Rusty Spike Podcast - episode 32](https://rusty-spike.blubrry.net/2018/06/07/episode-32-jun-6-2018/). 1.26.2 release, the arch (video and site), compiler speed-ups, crates.rs, and more thoughts on the Rust design process.
+
+Number: 239  Date: 2018-06-19 
+
+* [MIR-based borrow check (NLL) status update](http://smallcultfollowing.com/babysteps/blog/2018/06/15/mir-based-borrow-check-nll-status-update/).
+* [Divans: Open source compression](https://blogs.dropbox.com/tech/2018/06/building-better-compression-together-with-divans/) in Rust from Dropbox using threads, SIMD with a [WASM demo](https://dropbox.github.io/divans) in the browser.
+* [Integration tests](https://os.phil-opp.com/integration-tests/). Part of the series [Writing an OS in Rust](https://os.phil-opp.com/).
+* [From ActiveRecord to Diesel](http://patshaughnessy.net/2018/6/9/from-activerecord-to-diesel).
+* [Building a Diesel project on GitLab CI](https://noyez.gitlab.io/post/2018-06-15-rust-plus-diesel-plus-gitlab/).
+* [A trick for test maintenance](https://matklad.github.io/2018/06/18/a-trick-for-test-maintenance.html).
+* [Running Rust on the GPU with Accel](https://bheisler.github.io/post/rust-on-the-gpu-with-accel/).
+* [Rust on LPC82x microcontrollers using lpc82x-hal](https://users.rust-lang.org/t/lpc82x-hal-0-2-rust-on-lpc82x-microcontrollers/18144).
+* [Why Rust's async functions should use the outer return type approach](https://github.com/MajorBreakfast/rust-blog/blob/master/posts/2018-06-19-outer-return-type-approach.md).
+* [aturon.log: listening and trust, part 3](https://aturon.github.io/2018/06/18/listening-part-3/).
+* [This week in Rust and WebAssembly 3](https://rustwasm.github.io/2018/06/04/this-week-in-rust-wasm-003.html).
+* [podcast] [Rusty Spike Podcast - episode 33](https://rusty-spike.blubrry.net/2018/06/13/episode-33-jun-13-2018/). Crossbeam channels, actix benchmarks (and how to use it), qt, servo, gfx-portability, debian, OS development, LibOS, and a new book.
+
+Number: 240  Date: 2018-06-26 
+
+* 🎈🎉 [Announcing Rust 1.27](https://blog.rust-lang.org/2018/06/21/Rust-1.27.html). 🎉🎈
+* [Rust 2018: an early preview](https://internals.rust-lang.org/t/rust-2018-an-early-preview/7776).
+* [Our vision for Rust and WebAssembly](https://rustwasm.github.io/2018/06/25/vision-for-rust-and-wasm.html).
+* [Proposal for a staged RFC process](http://smallcultfollowing.com/babysteps/blog/2018/06/20/proposal-for-a-staged-rfc-process/).
+* [What I learned: Porting Dateutil parser from Python to Rust](https://speice.io/2018/06/dateutil-parser-to-rust.html).
+* [Making `Arc` more atomic](https://vorner.github.io/2018/06/24/arc-more-atomic.html).
+* [Optimising path tracing: the last 10%](https://bitshifter.github.io/2018/06/20/the-last-10-percent/).
+* [Rust with Rocket + Elm running on Heroku](http://ethanfrei.com/posts/rust-with-rocket-elm-running-on-heroku.html).
+* [Generic associated types in iterators](https://boiethios.gitlab.io/blog/2018-06-21_GATs_iterators.html).
+* [podcast] [Rusty Spike Podcast - episode 34](https://rusty-spike.blubrry.net/2018/06/20/episode-34-jun-20-2018/). DivANS, IDE support, Aaron’s continued series, async/await, non-lexical lifetimes, and Rust Reach.
+* [podcast] [New Rustacean: e024 – Traits deep dive, part 2](https://newrustacean.com/show_notes/e024/).
+
+Number: 241  Date: 2018-07-03 
+
+* [Rust 2018: the home stretch](https://internals.rust-lang.org/t/rust-2018-the-home-stretch/7810).
+* [Microsoft announces using Rust to build some of its Azure IoT functionality](https://twitter.com/maxgortman/status/1012011425353461760).
+* [Learning SIMD with Rust by finding planets](https://medium.com/@Razican/learning-simd-with-rust-by-finding-planets-b85ccfb724c3).
+* [`llvm-tools`, a new rustup component for binary inspection (objdump, nm, size) and profiling (profdata)](https://internals.rust-lang.org/t/llvm-tools-a-new-rustup-component-for-binary-inspection-objdump-nm-size-and-profiling-profdata/7830).
+* [How much Rust in Firefox](https://4e6.github.io/firefox-lang-stats/)?
+* [A rusty go at channels](https://gsquire.github.io/static/post/a-rusty-go-at-channels/).
+* [Better HTTP upgrades with hyper](http://seanmonstar.com/post/175280388657/better-http-upgrades-with-hyper).
+* [Our Vision for wasm-bindgen](https://rustwasm.github.io/2018/07/02/vision-for-wasm-bindgen.html).
+* [The Embedded WG newsletter 6](https://internals.rust-lang.org/t/the-embedded-working-group-newsletter-6/7842).
+* [podcast] [Rusty Spike Podcast - episode 35](https://rusty-spike.blubrry.net/2018/06/28/episode-35-june-27-2018/). Rust 1.27, new books, Microsoft, Eclipse, converting C to Rust, the Rust 2018 preview, the Rust 2018 roadmap, and RFCs.
+* [podcast] [New Rustacean news – Rust 1.27](https://newrustacean.com/show_notes/e024/). Stable SIMD, dyn trait, rustfix and the alpha release of the Rust 2018 Edition Preview.
+
+Number: 242  Date: 2018-07-10 
+
+* 🎈🎉 [Announcing Rust 1.27.1](https://blog.rust-lang.org/2018/07/10/Rust-1.27.1.html). 🎉🎈
+* [Use of unsafe in actix-web codebase is down to <15 from 100+](https://www.reddit.com/r/rust/comments/8wlkbe/actixweb_has_removed_all_unsound_use_of_unsafe_in/).
+* [Rust + actix-web in one of the biggest music festival Atlas Weekend](https://www.reddit.com/r/rust/comments/8xdsx5/rust_actixweb_in_the_on_of_the_biggest_music/).
+* [A web application completely written in Rust](https://medium.com/@saschagrunert/a-web-application-completely-in-rust-6f6bdb6c4471).
+* [Debian is starting to package Rust crates](https://www.reddit.com/r/rust/comments/8w9mfy/debian_is_starting_to_package_rust_crates/).
+* [Relative paths in Rust 2018](https://internals.rust-lang.org/t/relative-paths-in-rust-2018/7883).
+* [Exploring new communication channels](https://internals.rust-lang.org/t/exploring-new-communication-channels/7859). Some Rust teams are trying out the Discord chat platform for team discussions.
+* [Security Advisory for rustdoc](https://blog.rust-lang.org/2018/07/06/security-advisory-for-rustdoc.html).
+* [Programming for Redox OS](https://dev.to/legolord208/programming-for-redox-os-4124).
+* [Programming Servo: an HTTP cache](https://medium.com/programming-servo/programming-servo-an-http-cache-edb52a7f267f).
+* [podcast] [New Rustacean: Traits deep dive, part 3](https://newrustacean.com/show_notes/e025/index.html). Closure traits, impl trait, dyn trait, and object safety.
+
+Number: 243  Date: 2018-07-17 
+
+* [Clippy is now available as a rustup component](https://internals.rust-lang.org/t/clippy-is-available-as-a-rustup-component/7967).
+* [Announcing State of Rust](https://internals.rust-lang.org/t/announcing-state-of-rust/7937).
+* [Auditing popular crates: how a one-line unsafe has nearly ruined everything](https://www.reddit.com/r/rust/comments/8zpp5f/auditing_popular_crates_how_a_oneline_unsafe_has/).
+* [The tale of a bug in Arc: Synchronization and data races](https://www.ralfj.de/blog/2018/07/13/arc-synchronization.html).
+* [Running Rust on a drone flight controller](https://www.joshmcguigan.com/blog/betafpv-drone-flight-controller-hello-rust/).
+* [Writing a GPU-accelerated path tracer in Rust - part 2](https://bheisler.github.io/post/writing-gpu-accelerated-path-tracer-part-2/).
+* [Programming Servo: a 'script' event-loop](https://medium.com/programming-servo/programming-servo-the-script-event-loop-be687b985b3e).
+* [Artifact 2.0 - Rust full stack web and cli application](https://vitiral.github.io/2018/07/16/artifact-2.0-rust-full-stack-web-and-cli-application.html).
+* [Compatibility with dependencies](https://github.com/teiesti/compdep/blob/master/compdep.pdf).
+* [This week in Rust and WebAssembly 4](https://rustwasm.github.io/2018/07/10/this-week-in-rust-wasm-004.html).
+* [The Embedded WG newsletter 7](https://internals.rust-lang.org/t/the-embedded-working-group-newsletter-7/7959).
+* [2018 Edition - end of week post (2018-07-13)](https://internals.rust-lang.org/t/2018-edition-end-of-week-post-2018-07-13/7943).
+* [Possible stabilizations for 2018 Edition Preview 2](https://internals.rust-lang.org/t/possible-stabilizations-for-2018-edition-preview-2/7983).
+
+Number: 244  Date: 2018-07-24 
+
+* 🎈🎉 [Announcing Rust 1.27.2](https://blog.rust-lang.org/2018/07/20/Rust-1.27.2.html). 🎉🎈
+* [Futures 0.3.0-alpha.1 is released with support for async/await](https://rust-lang-nursery.github.io/futures-rs/blog/2018/07/19/futures-0.3.0-alpha.1.html).
+* [Game studio Ready At Dawn switching to Rust for all new development](https://twitter.com/AndreaPessino/status/1021532074153394176).
+* [Multi-line search is coming to ripgrep](https://twitter.com/burntsushi5/status/1018995044861272064).
+* [Wayland-rs 0.21: Pure rust implementation](https://smithay.github.io/wayland-rs-v-0-21.html).
+* [A static web app in Rust](https://bluejekyll.github.io/blog/rust/2018/07/22/static-web-app-rust.html).
+* [Writing a GPU-accelerated path tracer in Rust - part 3](https://bheisler.github.io/post/writing-gpu-accelerated-path-tracer-part-3/).
+* [Creating CLI apps in Rust is super easy](https://blog.kuviman.com/2018/07/20/glitchcat.html).
+* [Deploying Rust with Docker and Kubernetes](https://www.fpcomplete.com/blog/2018/07/deploying-rust-with-docker-and-kubernetes).
+* [Natively run OCaml from Rust](https://blog.s-m.ac/ocaml-rust-ffi/).
+* [Rust concurrency patterns: communicate by sharing your Sender](https://medium.com/@polyglot_factotum/rust-concurrency-patterns-communicate-by-sharing-your-sender-11a496ce7791).
+* [Thoughts on compile-time function evaluation and type systems](https://www.ralfj.de/blog/2018/07/19/const.html).
+* [On impl blocks, injection and surjection in Rust](https://phaazon.net/blog/on-rust-impl-block).
+* [Rebooting the network services working group](https://internals.rust-lang.org/t/rebooting-the-network-services-working-group/8036).
+* [Hello Content-o-Tron](http://blog.community.rs/content-team/2018/07/16/hello-content-o-tron.html). Editorial assistance and technical reviews of draft blog posts.
+* [2018 Edition end of week post (2018-07-20)](https://internals.rust-lang.org/t/2018-edition-end-of-week-post-2018-07-20/8019).
+
+Number: 245  Date: 2018-07-31 
+
+* [What is Rust 2018](https://blog.rust-lang.org/2018/07/27/what-is-rust-2018.html)?
+* [Announcing the js-sys crate](https://rustwasm.github.io/2018/07/26/announcing-the-js-sys-crate.html).
+* [Learn how to build OpenGL renderer with Rust](https://old.reddit.com/r/rust/comments/92abkg/rust_and_opengl_from_scratch_a_blog_post_series/).
+* [A snapshot of Rust's popularity in July 2018](http://www.jonathanturner.org/2018/07/snapshot-of-rust-popularity.html).
+* [Pointers are complicated, or: What's in a byte](https://www.ralfj.de/blog/2018/07/24/pointers-and-bytes.html)?
+* [Version selection in Cargo](https://aturon.github.io/2018/07/25/cargo-version-selection/).
+* [A "rustup target" example: Using a Mac to cross-compile Linux binaries](http://timryan.org/2018/07/27/cross-compiling-linux-binaries-from-macos.html).
+* [Rust concurrency patterns: Natural born pipelines](https://medium.com/@polyglot_factotum/rust-concurrency-patterns-natural-born-pipelines-4d599e7612fc).
+* [Build a sequence-based recommender system in Rust](https://maciejkula.github.io/2018/07/27/recommending-books-with-rust/).
+* [Programming Servo: How to match](https://medium.com/programming-servo/programming-servo-how-to-match-b76c43f76fe6).
+* [My experience with the Rust 2018 preview](https://boats.gitlab.io/blog/post/my-experience-with-rust-2018/).
+* [Writing a front-end WebAssembly framework in Rust: lessons learned](https://medium.com/@robert.balicki_2494/writing-a-front-end-webassembly-framework-in-rust-lessons-learned-7cc48ed27d96).
+* [2018 edition end of week post (2018-07-27)](https://internals.rust-lang.org/t/2018-edition-end-of-week-post-2018-07-27/8078).
+* [The Embedded WG newsletter 8](https://internals.rust-lang.org/t/the-embedded-working-group-newsletter-8/8089).
+* [Rust 2018 release schedule and extended beta](https://internals.rust-lang.org/t/rust-2018-release-schedule-and-extended-beta/8076).
+
+Number: 246  Date: 2018-08-07 
+
+* 🎈🎉 [Announcing Rust 1.28](https://blog.rust-lang.org/2018/08/02/Rust-1.28.html). 🎉🎈
+* [warp: a new web framework for Rust](https://seanmonstar.com/post/176530511587/warp).
+* [Data manipulation in Rust (Part 1: nalgebra)](https://misoraclette.github.io/2018/08/04/data_manipulation.html).
+* [Rust and the case of the redundant comparison](https://blog.dend.ro/rust-and-the-case-of-the-redundant-comparison/).
+* [Solving the generalized streaming iterator problem without GATs](https://lukaskalbertodt.github.io/2018/08/03/solving-the-generalized-streaming-iterator-problem-without-gats.html).
+* [Stacked borrows: An aliasing model for Rust](https://www.ralfj.de/blog/2018/08/07/stacked-borrows.html).
+* [Amethyst game engine: New tutorial and huge feature update](https://www.amethyst.rs/blog/release-0-8/).
+* [`intl_pluralrules` - A new crate for CLDR plural rules](https://blog.mozilla.org/l10n/2018/08/03/intl_pluralrules-a-rust-crate-for-handling-plural-forms-with-cldr-plural-rules/).
+* [Notes on two PRs that slightly improve Rust's performance](https://llogiq.github.io/2018/08/04/improve.html).
+* [Rust concurrency patterns: No context, no cancel, no leaks](https://medium.com/@polyglot_factotum/rust-concurrency-patterns-no-context-no-cancel-no-leak-b6c1ec2dafa5).
+* [ripgrep is now packaged in Debian](https://packages.debian.org/sid/ripgrep).
+* [This week in Rust and WebAssembly 5](https://rustwasm.github.io/2018/08/01/this-week-in-rust-wasm-005.html).
+* [2018 Edition end of week post (2018-08-04)](https://internals.rust-lang.org/t/2018-edition-end-of-week-post-2018-08-04/8123).
+
+Number: 247  Date: 2018-08-14 
+
+* [Launching the 2018 State of Rust Survey](https://blog.rust-lang.org/2018/08/08/survey.html).
+* [Discord's new game store makes extensive use of Rust](https://twitter.com/ManishEarth/status/1027676698068713473).
+* [How to alleviate the pain of Rust compile times](https://vfoley.xyz/rust-compile-speed-tips/).
+* [Never patterns, exhaustive matching, and uninhabited types](http://smallcultfollowing.com/babysteps/blog/2018/08/13/never-patterns-exhaustive-matching-and-uninhabited-types-oh-my/).
+* [Benchmarking gfx-portability versus MoltenVK and OpenGL with Dota2 on Mac](https://gfx-rs.github.io/2018/08/10/dota2-macos-performance.html).
+* [Tower Web — A new web framework for Rust](https://medium.com/@carllerche/tower-web-a-new-web-framework-for-rust-e2912856851b).
+* [The state of GPGPU in Rust](https://bheisler.github.io/post/state-of-gpgpu-in-rust/).
+* [The Xi text engine CRDT](https://github.com/google/xi-editor/blob/e8065a3993b80af0aadbca0e50602125d60e4e38/doc/crdt-details.md).
+* [The WG-Net vision for Rust 2018](https://rust-lang-nursery.github.io/wg-net/2018/08/09/going-live.html).
+* [The Embedded WG newsletter 9](https://internals.rust-lang.org/t/the-embedded-working-group-newsletter-9/8185).
+* [DX11 backend for gfx-rs - GSoC 2018 report](https://gfx-rs.github.io/2018/08/14/gsoc.html).
+
+Number: 248  Date: 2018-08-21 
+
+* [Announcing Rust 2018 Preview 2](https://internals.rust-lang.org/t/annoucning-rust-2018-preview-2/8218). <small>[[discuss](https://www.reddit.com/r/rust/comments/97mpt0/annoucning_rust_2018_preview_2/)]</small>
+* [Announcing the RLS 1.0 release candidate](https://www.ncameron.org/blog/rls-1-0-release-candidate/). <small>[[discuss](https://www.reddit.com/r/rust/comments/98gqsg/announcing_the_rls_10_release_candidate/)]</small>
+* [How Rust’s standard library was vulnerable for years and nobody noticed](https://medium.com/@shnatsel/how-rusts-standard-library-was-vulnerable-for-years-and-nobody-noticed-aebf0503c3d6). <small>[[discuss](https://www.reddit.com/r/rust/comments/988euh/how_rusts_standard_library_was_vulnerable_for/)]</small>
+* [Safe partial initialization in Rust](https://scottjmaddox.github.io/Safe-partial-initialization-in-Rust/). <small>[[discuss](https://www.reddit.com/r/rust/comments/98nmge/safe_partial_initialization_in_rust/)]</small>
+* [With undefined behavior, anything is possible](https://raphlinus.github.io/programming/rust/2018/08/17/undefined-behavior.html). <small>[[discuss](https://www.reddit.com/r/rust/comments/985id0/with_undefined_behavior_anything_is_possible/)]</small>
+* [Rust GraphQL webserver with Warp, Juniper, and MongoDB](http://alex.amiran.it/post/2018-08-16-rust-graphql-webserver-with-warp-juniper-and-mongodb.html). <small>[[discuss](https://www.reddit.com/r/rust/comments/97zlav/rust_graphql_webserver_with_warp_juniper_mongodb/)]</small>
+* [Programming Servo: Anatomy of a fetch](https://medium.com/programming-servo/anatomy-of-a-fetch-8872a5c843cd). <small>[[discuss](https://www.reddit.com/r/rust/comments/986p56/programming_servo_anatomy_of_a_fetch/)]</small>
+* [Thanks for asking](https://llogiq.github.io/2018/08/16/ask.html). An analysis of questions that are asked on r/rust subreddit. <small>[[discuss](https://www.reddit.com/r/rust/comments/97ps8m/blog_thanks_for_asking/)]</small>
+* [This week in Rust and WebAssembly 6](https://rustwasm.github.io/2018/08/14/this-week-in-rust-wasm-006.html). <small>[[discuss](https://www.reddit.com/r/rust/comments/97ah4r/this_week_in_rust_and_webassembly_6/)]</small>
+* [podcast] [New Rustacean news: Rust 1.28](https://newrustacean.com/show_notes/news/rust_1_28/). <small>[[discuss](https://www.reddit.com/r/rust/comments/98tkve/new_rustaceannews_rust_128/)]</small>
+
+Number: 249  Date: 2018-08-28 
+
+* [Experimental async / await support for Tokio](https://tokio.rs/blog/2018-08-async-await/). <small>[[discuss](https://www.reddit.com/r/rust/comments/9as61i/tokio_experimental_async_await_support/)]</small>
+* [Nightly Rust is switching to use LLD (LLVM's new built-in linker) as the default linker for ARM microcontrollers](https://rust-embedded.github.io/blog/2018-08-2x-psa-cortex-m-breakage/). <small>[[discuss](https://www.reddit.com/r/rust/comments/9a7te2/nightly_rust_is_switching_to_use_lld_llvms_new/)]</small>
+* [CVE-2018-1000657: buffer overflow in VecDeque::reserve() in Rust 1.3 through 1.21 allows arbitrary code execution](https://www.reddit.com/r/rust/comments/9926jq/cve20181000657_buffer_overflow_in_vecdequereserve/). <small>[[discuss](https://www.reddit.com/r/rust/comments/9926jq/cve20181000657_buffer_overflow_in_vecdequereserve/)]</small>
+* [More on the RLS and a 1.0 release](https://www.ncameron.org/blog/more-on-the-rls-and-a-1-0-release/). <small>[[discuss](https://www.reddit.com/r/rust/comments/99ltpr/more_on_the_rls_and_a_10_release/)]</small>
+* [Another look at the pinning API](https://boats.gitlab.io/blog/post/rethinking-pin/). <small>[[discuss](https://www.reddit.com/r/rust/comments/99iqdy/another_look_at_the_pinning_api/)]</small>
+* [Oxidizing sourmash: Python and FFI](https://blog.luizirber.org/2018/08/23/sourmash-rust/). <small>[[discuss](https://www.reddit.com/r/rust/comments/99vakd/blog_post_converting_c_to_rust_and_interoperate)]</small>
+* [Reading files quickly in Rust](https://boyter.org/posts/reading-files-quickly-in-rust/). <small>[[discuss](https://www.reddit.com/r/rust/comments/99e4tq/reading_files_quickly_in_rust/)]</small>
+* [Calling C# natively from Rust](https://medium.com/@chyyran/calling-c-natively-from-rust-1f92c506289d). <small>[[discuss](https://www.reddit.com/r/rust/comments/99z7bd/calling_c_natively_from_rust/)]</small>
+* [Programming Servo: the makings of a task-queue](https://medium.com/programming-servo/programming-servo-the-makings-of-a-task-queue-b4138cd246ca). <small>[[discuss](https://www.reddit.com/r/rust/comments/9axo53/programming_servo_the_makings_of_a_taskqueue/)]</small>
+* [Programming Servo: The debug way](https://medium.com/coding-neutrino-blog/programming-servo-the-debug-way-5db01f09b7f4). <small>[[discuss](https://www.reddit.com/r/rust/comments/9anveo/programming_servo_the_debug_way_debug_servo_and/)]</small>
+* [Easy `proc_macro_derive`s with `synstructure`](https://llogiq.github.io/2018/08/25/synstruct.html). <small>[[discuss](https://llogiq.github.io/2018/08/25/synstruct.html)]</small>
+* [Two kinds of invariants](https://www.ralfj.de/blog/2018/08/22/two-kinds-of-invariants.html), proposing rules for unsafe code concerning uninitialized data. <small>[[discuss](https://www.reddit.com/r/rust/comments/99g5b1/two_kinds_of_invariants/)]</small>
+* [Next Rust Fest to take place in Rome on 24 and 25 November](https://blog.rustfest.eu/next-stop-rome). <small>[[discuss](https://www.reddit.com/r/rust/comments/99w5vp/let_rome_rust_festnext_rustfest_november_24th_25th/)]</small>
+
+Number: 250  Date: 2018-09-04 
+
+* [Why Rust closures are (somewhat) hard](http://stevedonovan.github.io/rustifications/2018/08/18/rust-closures-are-hard.html).
+* [Rust pattern: Iterating an over a `Rc<Vec<T>>`](http://smallcultfollowing.com/babysteps/blog/2018/09/02/rust-pattern-iterating-an-over-a-rc-vec-t/).
+* [FlatBuffers adds support for Rust](https://github.com/google/flatbuffers/pull/4898).
+* [RPCS3 and Dolphin on macOS using gfx-portability](https://gfx-rs.github.io/2018/09/03/rpcs3-dolphin.html).
+* [Learning generics in Rust](https://tutorialedge.net/rust/learning-generics-in-rust/).
+* [Feasible functors in Rust](https://varkor.github.io/blog/2018/08/28/feasible-functors-in-rust.html).
+* [Programming Servo: A generic “worker event-loop”](https://medium.com/programming-servo/programming-servo-a-generic-worker-event-loop-400a6f113a60).
+* [Serde deserialize This or That into u64](https://noyez.gitlab.io/post/2018-08-28-serilize-this-or-that-into-u64/).
+* [This Week in Rust and WebAssembly 7](https://rustwasm.github.io/2018/09/04/this-week-in-rust-wasm-007.html).
+* [The Embedded WG newsletter 10](https://rust-embedded.github.io/blog/2018-08-28-newsletter-10/).
+
+Number: 251  Date: 2018-09-11 
+
+* [ripgrep 0.10.0 released (PCRE2 and multi-line support)](https://github.com/BurntSushi/ripgrep/releases/tag/0.10.0).
+* [rustfmt, compiled to wasm, in a webpage](https://alexcrichton.github.io/rustfmt-wasm/).
+* [Rust faster – SIMD edition](https://llogiq.github.io/2018/09/06/fast.html).
+* [2019 Strategy for rustc and the RLS](https://internals.rust-lang.org/t/2019-strategy-for-rustc-and-the-rls/8361).
+* [Adventures in Rust: Futures and Tokio](http://bryangilbert.com/post/code/rust/adventures-futures-tokio-rust/).
+* [From Rust to beyond, episode 4: The C galaxy](https://mnt.io/2018/09/11/from-rust-to-beyond-the-c-galaxy/). An end-to-end example, includes cbindgen and clang.
+* [Parallelizing PNG, part 5: choosing Rust for mtpng](https://brionv.com/log/2018/09/09/parallelizing-png-part-5-choosing-rust-for-mtpng/).
+* [Tower Web - Expanding the middleware stack](https://medium.com/@carllerche/tower-web-expanding-the-middleware-stack-f9bf55bfa109).
+* [Beware the rust cache on Travis (or why you should use it with care)](https://levans.fr/rust_travis_cache.html).
+* [RustFest Rome CFP is open and supporter tickets available](https://blog.rustfest.eu/this-week-in-rustfest-0-cfp-and-tickets).
+* [Videos from RustConf 2018](https://www.youtube.com/playlist?list=PL85XCvVPmGQi3tivxDDF1hrT9qr5hdMBZ).
+* [Rust Embedded WG newsletter 11](https://rust-embedded.github.io/blog/2018-09-09-newsletter-11/).
+
+Number: 252  Date: 2018-09-18 
+
+* 🎈🎉 [Announcing Rust 1.29](https://blog.rust-lang.org/2018/09/13/Rust-1.29.html). 🎉🎈
+* [Ripgrep is available as a package in Ubuntu 18.10](https://github.com/BurntSushi/ripgrep/pull/1054).
+* [WebRender is now enabled by default in Firefox Nightly on Windows 10 with Nvidia GPUs](https://groups.google.com/forum/#!topic/mozilla.dev.platform/x_sFbDgQJP0).
+* [RustConf 2018 closing keynote (blog post)](https://kyren.github.io/2018/09/14/rustconf-talk.html).
+* [Rising Tide: building a modular web framework in the open](https://rust-lang-nursery.github.io/wg-net/2018/09/11/tide.html).
+* [You can’t “turn off the borrow checker” in Rust](https://words.steveklabnik.com/you-can-t-turn-off-the-borrow-checker-in-rust).
+* [Measuring SmallVec footprint with Smallvectune](https://llogiq.github.io/2018/09/13/smallvec.html).
+* [How we organize a complex Rust codebase](https://blog.getseq.net/rust-at-datalust-how-we-organize-a-complex-rust-codebase/).
+* [Desktop apps with Rust (Electorn + WebAssembly)](https://speice.io/2018/09/isomorphic-apps.html).
+* [Postgres over TLS with the postgres crate, r2d2_postgres and openssl](https://matthewkmayer.github.io/blag/public/post/postgres-tls/).
+* [The Networking WG newsletter 1](https://internals.rust-lang.org/t/the-networking-working-group-newsletter-01/8391).
+
+Number: 253  Date: 2018-09-25 
+
+* 🎈🎉 [Announcing Rust 1.29.1](https://blog.rust-lang.org/2018/09/25/Rust-1.29.1.html). 🎉🎈
+* [Citybound: Introducing live builds](http://aeplay.co/citybound-devblog/introducing-live-builds).
+* [The biggest wasm-pack release yet](https://rustwasm.github.io/2018/09/24/the-biggest-wasm-pack-release-yet.html).
+* [Office hours with Niko Matsakis: Debugging with GDB](http://smallcultfollowing.com/babysteps/blog/2018/09/21/office-hours-0-debugging-with-gdb/).
+* [Office hours with Niko Matsakis: Cyclic services](http://smallcultfollowing.com/babysteps/blog/2018/09/24/office-hours-1-cyclic-services/).
+* [Rust on iOS: How to](https://github.com/mtak-/rust-on-mobile/blob/master/examples/ios/example01.md).
+* [A Rust FFI adventure in unsafety](https://travisf.net/capstone-rs-unsafety-adventure).
+* [How to integrate Rust with C#](https://blog.getseq.net/rust-at-datalust-how-we-integrate-rust-with-csharp/).
+* [Rewriting a bash script in Rust](https://wiredforge.com/blog/misc/getpid/index.html).
+* [Creating a robot for Eurobot in Rust: The context](https://blog.florencepaul.com/creating-a-robot-for-eurobot-part-1-context).
+* [Incinerator: The ABA problem and concurrent reclamation](https://bzim.gitlab.io/blog/posts/incinerator-the-aba-problem-and-concurrent-reclamation.html).
+
+Number: 254  Date: 2018-10-02 
+
+* [Announcing the web-sys crate](https://rustwasm.github.io/2018/09/26/announcing-web-sys.html)!
+* [The relative performance of C and Rust](http://dtrace.org/blogs/bmc/2018/09/28/the-relative-performance-of-c-and-rust/).
+* [Understanding compilers — for humans (version 2)](https://towardsdatascience.com/understanding-compilers-for-humans-version-2-157f0edb02dd).
+* [How I’ve found vulnerability in a popular Rust crate (and you can too)](https://medium.com/@shnatsel/how-ive-found-vulnerability-in-a-popular-rust-crate-and-you-can-too-3db081a67fb).
+* [lolbench: automagically and empirically discovering Rust performance regressions](https://blog.anp.lol/rust/2018/09/29/lolbench/).
+* [This week in Rust and WebAssembly 8](https://rustwasm.github.io/2018/10/01/this-week-in-rust-wasm-008.html).
+* [The embedded WG newsletter 12](https://rust-embedded.github.io/blog/2018-09-25-newsletter-12/).
+
+Number: 255  Date: 2018-10-09 
+
+* [Porting C to Rust, a case study: minimp3](https://wiki.alopex.li/PortingCToRust).
+* [Lessons learned on writing web applications completely in Rust](https://medium.com/@saschagrunert/lessons-learned-on-writing-web-applications-completely-in-rust-2080d0990287).
+* [comacro: a declarative building block for static analysis](http://blog.lambdaverse.org/comacro).
+* [Oxidizing Python: Speeding up URL quoting by 10x using Rust](https://tech.blue-yonder.com/oxidizing-python-speeding-up-urlquoting-by-using-rust/).
+* [GLSL quasiquoting in Rust](https://phaazon.net/blog/glsl-quasiquoting).
+* [Going four times faster using multi-threading](http://worthe-it.co.za/programming/2018/10/03/going-four-times-faster-with-multithreading.html).
+* [Bluetooth Low Energy with Rust](https://219design.com/bluetooth-low-energy-with-rust/).
+* [Hunting for bugs in Rust](https://blog.troutwine.us/2018/10/08/hunting-for-bugs-in-rust/).
+* [Who authors the most popular crates on crates.io](https://words.steveklabnik.com/who-authors-the-most-popular-crates-on-crates-io)?
+* [Rust's story for default arguments](https://medium.com/@softprops/default-values-copy-that-ae43831781f3).
+* [Remacs continues to improve](http://db48x.net/rust-remacs-2018/).
+* [Future directions for cbindgen (rust-ffi)](http://dreamingofbits.com/post/future-directions-for-cbindgen-rust-ffi/).
+* [The Embedded WG newsletter 13](https://rust-embedded.github.io/blog/2018-10-09-newsletter-13/).
+
+Number: 256  Date: 2018-10-16 
+
+* 🎈🎉 [Announcing Rust 1.29.2](https://blog.rust-lang.org/2018/10/12/Rust-1.29.2.html). 🎉🎈
+* [Rust has a static garbage collector](https://words.steveklabnik.com/borrow-checking-escape-analysis-and-the-generational-hypothesis).
+* [Serverless Rust with Cloudflare Workers](https://blog.cloudflare.com/cloudflare-workers-as-a-serverless-rust-platform/).
+* [Notes on type layouts and ABIs in Rust](https://gankro.github.io/blah/rust-layouts-and-abis/).
+* [Game dev from zero - part 1: Hello, Rust lang](https://hashnode.com/post/game-dev-from-zero-part-1-hello-rust-lang-cjn3brwto001jv7s2e533bdfc).
+* [Fixing a Clippy crash](https://phansch.net/2018/10/10/fixing-a-clippy-crash/).
+* [Handling configurations in a Rust app with envy](https://medium.com/@softprops/configuration-envy-a09584386705).
+* [Routing and extraction in Tide: a first sketch](https://rust-lang-nursery.github.io/wg-net/2018/10/16/tide-routing.html).
+* [Amethyst is growing; news on ongoing projects](https://www.amethyst.rs/blog/dev-news-10-2018/).
+
+Number: 257  Date: 2018-10-23 
+
+* [Writing an OS in Rust: Hardware interrupts](https://os.phil-opp.com/hardware-interrupts/).
+* [Towards fearless SIMD](https://raphlinus.github.io/rust/simd/2018/10/19/fearless-simd.html).
+* [Shifgrethor I: Garbage collection as a Rust library](https://boats.gitlab.io/blog/post/shifgrethor-i/).
+* [Update on the October 15, 2018 incident on crates.io](https://blog.rust-lang.org/2018/10/19/Update-on-crates.io-incident.html).
+* [docs.rs is now part of the rust-lang-nursery organization](https://github.com/rust-lang-nursery/docs.rs).
+* [Is Rust functional](https://www.fpcomplete.com/blog/2018/10/is-rust-functional)?
+* [Multithreading Rust and WebAssembly](https://rustwasm.github.io/2018/10/24/multithreading-rust-and-wasm.html).
+* [Rust has higher kinded types already... sort of](https://joshlf.com/post/2018/10/18/rust-higher-kinded-types-already/).
+* [Auth web microservice with Rust using actix-web](https://hgill.io/posts/auth-microservice-rust-actix-web-diesel-complete-tutorial-part-1/).
+
+Number: 258  Date: 2018-10-30 
+
+* 🎈🎉 [Announcing Rust 1.30](https://blog.rust-lang.org/2018/10/25/Rust-1.30.0.html). 🎉🎈
+* [Parsing logs 230x faster with Rust](https://andre.arko.net/2018/10/25/parsing-logs-230x-faster-with-rust/).
+* [Shifgrethor III: Rooting](https://boats.gitlab.io/blog/post/shifgrethor-iii/).
+* [A release checklist for Rust programs](https://dev.to/sharkdp/my-release-checklist-for-rust-programs-1m33).
+* [2d graphics in Rust discussion - A look at GPU memory management](https://nical.github.io/posts/rust-2d-graphics-02.html).
+* [Announcing Gotham 0.3](https://gotham.rs/blog/release/2018/10/29/gotham-0.3.html).
+* [Finding and fixing memory leaks in a Hyper application](https://blog.1aim.com/2018/10/finding-and-fixing-memory-leaks-in-a-hyper-application-or-how-i-learned-to-stop-worrying-and-love-the-allocator/).
+* [A brief introduction to serverless applications in Rust](https://medium.com/@softprops/serverless-rust-318732a3596).
+* [The case for macros](https://llogiq.github.io/2018/10/25/macros.html).
+* [Jim Blandy interview on mastering moves and borrows](https://corecursive.com/016-moves-and-borrowing-in-rust-with-jim-blandy/).
+* [The Embedded WG newsletter 14](https://rust-embedded.github.io/blog/2018-10-28-newsletter-14/).
+
+Number: 259  Date: 2018-11-06 
+
+* [Rust now available on 14 Debian architectures](https://lists.debian.org/debian-devel-announce/2018/11/msg00000.html).
+* [MIR-based borrowck is almost here](http://smallcultfollowing.com/babysteps/blog/2018/10/31/mir-based-borrowck-is-almost-here/).
+* [How to speed up the Rust compiler in 2018: NLL edition](https://blog.mozilla.org/nnethercote/2018/11/06/how-to-speed-up-the-rust-compiler-in-2018-nll-edition/).
+* [After NLL: Interprocedural conflicts](http://smallcultfollowing.com/babysteps/blog/2018/11/01/after-nll-interprocedural-conflicts/).
+* [Shifgrethor IV: Tracing](https://boats.gitlab.io/blog/post/shifgrethor-iv/).
+* [A hammer you can only hold by the handle](https://blog.systems.ethz.ch/blog/2018/a-hammer-you-can-only-hold-by-the-handle.html). Looking at the Rust borrow checker from a different perspective.
+* [Anchored and uniform paths](https://boats.gitlab.io/blog/post/anchored-uniform/).
+* [On dealing with owning and borrowing in public interfaces](https://phaazon.net/blog/on-owning-borrowing-pub-interface).
+
+Number: 260  Date: 2018-11-13 
+
+* 🎈🎉 [Announcing Rust 1.30.1](https://blog.rust-lang.org/2018/11/08/Rust-1.30.1.html). 🎉🎈
+* [Things Rust doesn’t let you do](https://medium.com/@GolDDranks/things-rust-doesnt-let-you-do-draft-f596a3c740a5).
+* [After NLL: Moving from borrowed data and the sentinel pattern](http://smallcultfollowing.com/babysteps/blog/2018/11/10/after-nll-moving-from-borrowed-data-and-the-sentinel-pattern/).
+* [Running Rust natively in AWS Lambda and testing it locally](https://medium.com/@bernardo.belchior1/running-rust-natively-in-aws-lambda-and-testing-it-locally-57080421426d).
+* [Truly zero cost abstractions](https://vorner.github.io/2018/11/11/truly-zero-cost.html).
+* [Implementing Rust’s `std::sync::Mutex` in D](https://atilanevesoncode.wordpress.com/2018/11/06/implementing-rusts-stdsyncmutex-in-d/).
+* [Middleware in Tide](https://rust-lang-nursery.github.io/wg-net/2018/11/07/tide-middleware.html).
+* [Monadic do notation in Rust: Part I](https://varkor.github.io/blog/2018/11/10/monadic-do-notation-in-rust-part-i.html).
+* [`proc_macro_attribute` revisited](https://llogiq.github.io/2018/11/10/proc-macro.html).
+* [pdf] [Writing network drivers in Rust](https://www.net.in.tum.de/fileadmin/bibtex/publications/theses/2018-ixy-rust.pdf).
+
+Number: 261  Date: 2018-11-20 
+
+* [A verified email address will be required to publish to crates.io starting on 2019-02-28](https://users.rust-lang.org/t/a-verified-email-address-will-be-required-to-publish-to-crates-io-starting-on-2019-02-28/22425).
+* [Rust and game development](https://alexene.github.io/2018/11/15/Rust-and-game-development.html).
+* [Build your own shell using Rust](https://www.joshmcguigan.com/blog/build-your-own-shell-rust/).
+* [Stacked borrows implemented: An aliasing model for Rust](https://www.ralfj.de/blog/2018/11/16/stacked-borrows-implementation.html).
+* [Bringing Elm's architecture to Rust and Webassembly](https://sindrejohansen.no/blog/willow/rust/elm/2018/11/16/willow-elm-in-rust.html).
+* [Programming Servo: a background-hang-monitor](https://medium.com/programming-servo/programming-servo-a-background-hang-monitor-73e89185ce1).
+* [Compile time feature flags in Rust](https://www.worthe-it.co.za/programming/2018/11/18/compile-time-feature-flags-in-rust.html).
+* [Program synthesis is possible in Rust](http://fitzgeraldnick.com/2018/11/15/program-synthesis-is-possible-in-rust.html).
+* [This year in embedded Rust](https://rust-embedded.github.io/blog/2018-11-14-this-year-in-embedded-rust/).
+
+Number: 262  Date: 2018-11-27 
+
+* [Announcing Rust 2018 Beta release](https://internals.rust-lang.org/t/announcing-rust-2018-beta-release/8901).
+* [Announcing Firecracker from Amazon: MicroVM for serverless computing](https://aws.amazon.com/blogs/opensource/firecracker-open-source-secure-fast-microvm-serverless/).
+* [Rust survey 2018 results](https://blog.rust-lang.org/2018/11/27/Rust-survey-2018.html).
+* [Getting started with nightly async/await support](https://jsdw.me/posts/rust-asyncawait-preview/).
+* [Converting AsyncRead and AsyncWrite to Futures, Sinks, and Streams](https://jsdw.me/posts/rust-futures-tokio/).
+* [Bootstrapping an embedded Rust development environment](https://josh.robsonchase.com/embedded-bootstrapping/).
+* [Tide's evolving middleware approach](https://rust-lang-nursery.github.io/wg-net/2018/11/27/tide-middleware-evolution.html).
+* [Rust traits and their (lack of) privacy](https://phaazon.net/blog/rust-traits-privacy).
+* [Serverless HTTP](https://medium.com/@softprops/serverless-http-9a58f9b2df60).
+* [Generic methods in Rust: How Exonum shifted from Iron to Actix-web](https://medium.com/meetbitfury/generic-methods-in-rust-how-exonum-shifted-from-iron-to-actix-web-7a2752171388).
+* [Rust+GNOME Hackfest 4](http://antoyo.ml/rust-gnome-hackfest-thessaloniki).
+* [Amethyst Foundation has been formed](https://www.amethyst.rs/blog/non-profit-announce/).
+* [Rust language cheat sheet (cheats.rs)](https://cheats.rs).
+* [Rust Latam CFP is now open, deadline is December 31st](https://cfp.rustlatam.org/events/rust-latam). Also [ticket sales are open](https://rustlatam.org/#tickets).
+* [Videos from Rust Belt Rust 2018 are now available](https://www.youtube.com/playlist?list=PLgC1L0fKd7UlpVTHVfLYVtudVx8CzbSxW).
+
+Number: 263  Date: 2018-12-04 
+
+* [A new look for rust-lang.org](https://blog.rust-lang.org/2018/11/29/a-new-look-for-rust-lang-org.html).
+* [Rust Quiz: 26 medium to hard Rust questions with complete explanations](https://dtolnay.github.io/rust-quiz/18).
+* [Announcing RustaCUDA](https://bheisler.github.io/post/announcing-rustacuda/).
+* [Official Rust runtime for AWS Lambda](https://aws.amazon.com/blogs/opensource/rust-runtime-for-aws-lambda/).
+* [Creating my first AWS Lambda using Rust](https://medium.com/@kkostov/rust-aws-lambda-30a1b92d4009).
+* [How I wrote a modern C++ library in Rust](https://hsivonen.fi/modern-cpp-in-rust/).
+* [Using Passenger with Rust](https://www.phusionpassenger.com/docs/advanced_guides/gls/rust.html).
+* [wasm-bindgen — how does it work](http://fitzgeraldnick.com/2018/12/02/wasm-bindgen-how-does-it-work.html)?
+* [Rust web survey 2018](https://rust-lang-nursery.github.io/wg-net/2018/11/28/wg-net-survey.html).
+* [This Week in Rust and WebAssembly 9](https://rustwasm.github.io/2018/11/28/this-week-in-rust-wasm-009.html).
+
+Number: 264  Date: 2018-12-11 
+
+* 🎈🎉 [Announcing Rust 1.31 and Rust 2018](https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html). 🎉🎈
+* [Rust 2018 is here… but what is it](https://hacks.mozilla.org/2018/12/rust-2018-is-here/)?
+* [Reflecting on Rust and WebAssembly in 2018](https://rustwasm.github.io/2018/12/06/reflecting-on-rust-and-wasm-in-2018.html).
+* [Rocket v0.4: Typed URIs, database support, revamped queries, & more](https://rocket.rs/v0.4/news/2018-12-08-version-0.4/).
+* [Inside Rust's async transform](https://blag.nemo157.com/2018/12/09/inside-rusts-async-transform.html).
+* [The Swiss army knife of hashmaps](https://blog.waffles.space/2018/12/07/deep-dive-into-hashbrown/).
+* [Building Alexa Skills in Rust](https://medium.com/@amalec/building-alexa-skills-in-rust-4cf54a497ea4).
+* [Wherefore art thou Romio](https://boats.gitlab.io/blog/post/romio/)? Romio is a port of a small part of the Tokio project to the newer futures APIs.
+* [Existential types in Rust](https://adelbertc.github.io/posts/2018-12-10-rust-existentials.html).
+* [Currying in Rust](https://hashnode.com/post/currying-in-rust-cjpfb0i2z00cm56s2aideuo4z).
+* [More on RLS version numbering](https://www.ncameron.org/blog/more-on-rls-version-numbering/).
+* [Patterns of Refactoring C to Rust: The case of librsvg](https://people.gnome.org/~federico/blog/guadec-2018-presentation.html).
+### #Rust2019
+* [Rust in 2022 (and 2019)](https://www.ncameron.org/blog/rust-in-2022/).
+* [Rust 2019: Think bigger](http://fitzgeraldnick.com/2018/12/11/rust-2019-think-bigger.html).
+* [The Fallow Year](https://www.jonathanturner.org/2018/12/the-fallow-year.html).
+* [eddyb's wishes for Rust in 2019](https://twitter.com/eddyb_r/status/1072444398284300289).
+* [pcwalton's plans for 2019](https://pcwalton.github.io/2018/12/07/plans-for-2019.html).
+* [Lokathor's Rust 2019 wishpost](https://www.reddit.com/r/rust/comments/a4ygji/lokathors_rust_2019_wishpost/).
+* [Rust 2019 - The road ahead](https://llogiq.github.io/2018/12/08/rust.html).
+* [2019 wishlist - Finish and ship the work that has already started](https://www.reddit.com/r/rust/comments/a3sav1/2019_roadmap_more_like_a_wishlist_finish_and_ship/).
+* [Rust 2019: a newbie's thoughts](https://www.reddit.com/r/rust/comments/a44txf/rust_2019_a_newbies_thoughts/).
+* [Rust 2019 — let us pursue composability](https://medium.com/@GolDDranks/rust-2019-let-us-pursue-composability-70f1eb2238c3).
+* [2019 Wishlist/Pain points](https://www.reddit.com/r/rust/comments/a59b3a/2019_wishlistpain_points/).
+* [Rust 2019 - Named argument syntax](https://twitter.com/PistonDeveloper/status/1072193819855196160).
+
+Number: 265  Date: 2018-12-18 
+
+* [Tools in the 2018 edition](https://blog.rust-lang.org/2018/12/17/Rust-2018-dev-tools.html).
+* [Making Rust float parsing fast and correct](https://www.reddit.com/r/rust/comments/a6j5j1/making_rust_float_parsing_fast_and_correct/).
+* [Bootstrapping Rust](https://www.gnu.org/software/guix/blog/2018/bootstrapping-rust/).
+* [Async in Rust, circa 2018](https://rust-lang-nursery.github.io/wg-net/2018/12/13/async-update.html).
+* [Rust Analyzer in 2018 and 2019](https://ferrous-systems.com/blog/rust-analyzer-2019/).
+* [Rust and WebAssembly in 2019](http://fitzgeraldnick.com/2018/12/14/rust-and-webassembly-in-2019.html).
+* [Storing unboxed trait objects in Rust](https://guiand.xyz/blog-posts/unboxed-trait-objects.html).
+* [Currying in Rust — Part 2 (A glimpse of generics)](https://hashnode.com/post/currying-in-rust-part-2-a-glimpse-of-generics-cjphbgun90025pms241ggh3d9).
+* [Building a JS Interpreter in Rust part 1](https://jason-williams.co.uk/building-a-js-interpreter-in-rust-part-1/).
+* [Edge programming with Rust and WebAssembly](https://www.fastly.com/blog/edge-programming-rust-web-assembly).
+### #Rust2019
+Find all #Rust2019 posts at [Read Rust](https://readrust.net/rust-2019/).
+
+Number: 266  Date: 2018-12-25 
+
+* 🎈🎉 [Announcing Rust 1.31.1](https://blog.rust-lang.org/2018/12/20/Rust-1.31.1.html). 🎉🎈
+* [Procedural macros in Rust 2018](https://blog.rust-lang.org/2018/12/21/Procedural-Macros-in-Rust-2018.html).
+* [Tokio: A great 2018, an even better 2019](https://tokio.rs/blog/2018-12-recap-2018/).
+* [Using C libraries in Rust: making a `*-sys` crate](https://kornel.ski/rust-sys-crate).
+* [Rust asynchronous IO: from mio to coroutine](https://github.com/Hexilee/async-io-demo).
+* [Methods for array initialization in Rust](https://www.joshmcguigan.com/blog/array-initialization-rust/).
+* [Currying in rust Part 3 (The circle of life... aka why borrowchecker... why)](https://hashnode.com/post/currying-in-rust-part-3-the-circle-of-life-aka-why-borrowchecker-why-cjq3z1dd800dknds1sls4dqav)!?
+* [How to get better at Rust: For beginners](https://hashnode.com/post/how-to-become-a-rust-super-developer-cjpv1ee7e000buhs2aqrdw2ym).
+### #Rust2019
+Find all #Rust2019 posts at [Read Rust](https://readrust.net/rust-2019/).
+
+Number: 267  Date: 2019-01-01 
+
+* [This year in gfx-rs: 2018](https://gfx-rs.github.io/2018/12/27/this-year.html).
+* [Comparing Pythagorean triples in C++, D, and Rust](https://atilanevesoncode.wordpress.com/2018/12/31/comparing-pythagorean-triples-in-c-d-and-rust/).
+* [My experience converting a Python library to Rust](https://alantrick.ca/writings/programming/python_to_rust/).
+### #Rust2019
+Find all #Rust2019 posts at [Read Rust](https://readrust.net/rust-2019/).
+
+Number: 268  Date: 2019-01-08 
+
+* [Rust cheat sheet for beginners](https://www.breakdown-notes.com/make/load/rust_cs_canvas/true).
+* [Deriving traits in Rust with procedural macros](https://naftuli.wtf/2019/01/02/rust-derive-macros/).
+* [Using Rust for Gamedev](https://medium.com/@michelotti.matthew/using-rust-for-gamedev-2f60b0e4cc5c).
+* [Are we async yet](https://areweasyncyet.rs/)?
+* [Building a JS interpreter in Rust part 2](https://jason-williams.co.uk/building-a-js-interpreter-in-rust-part-2).
+* [New Rustacean interview: Carol Nichols || Goulding and Jake Goulding](https://newrustacean.com/show_notes/interview/integer32/). Talking with Carol and Jake about The Rust Programming Language, Rust in Motion, and Rust Belt Rust.
+### #Rust2019
+Find all #Rust2019 posts at [Read Rust](https://readrust.net/rust-2019/).
+
+Number: 269  Date: 2019-01-15 
+
+* [Writing an OS in Rust: Introduction to paging](https://os.phil-opp.com/paging-introduction/).
+* [Librsvg is almost rustified now](https://people.gnome.org/~federico/blog/librsvg-is-almost-rustified.html).
+* [Understanding Rust lifetimes](https://medium.com/nearprotocol/understanding-rust-lifetimes-e813bcd405fa).
+* [const types, traits and implementations in Rust](https://varkor.github.io/blog/2019/01/11/const-types-traits-and-implementations-in-Rust.html).
+* [Generate Rust tests from data files](https://blog.cyplo.net/posts/2018/12/generate-rust-tests-from-data.html).
+* [The evolution of a Rust programmer](http://antoyo.ml/evolution-rust-programmer).
+### #Rust2019
+Find all #Rust2019 posts at [Read Rust](https://readrust.net/rust-2019/).
+
+Number: 270  Date: 2019-01-22 
+
+* 🎈🎉 [Announcing Rust 1.32.0](https://blog.rust-lang.org/2019/01/17/Rust-1.32.0.html). 🎉🎈
+* [A bot for Starcraft in Rust, C, or any other language](https://habr.com/en/post/436254/).
+* [Building JavaScript development tools in Rust](https://freemasen.github.io/rusty-ecma-book/).
+* [Guide to rust-analyzer](https://github.com/rust-analyzer/rust-analyzer/blob/e0d8c86563b72e5414cf10fe16da5e88201447e2/guide.md).
+* [The state of ggez, 2019](https://wiki.alopex.li/TheStateOfGGEZ2019).
+* [proc-macro-rules - macro_rules patterns in procedural macros](https://www.ncameron.org/blog/proc-macro-rules/).
+* [Polonius and region errors](http://smallcultfollowing.com/babysteps/blog/2019/01/17/polonius-and-region-errors/).
+* [Why aren't my Rust threads running](https://esimmler.com/why-arent-my-rust-threads-running/)?
+* [Paw at Rust GUIs](https://medium.com/@m.siglreith/paw-at-rust-guis-d4d848e14b94).
+* [Serialising Rust tests](https://tech.labs.oliverwyman.com/blog/2019/01/14/serialising-rust-tests/).
+### #Rust2019
+Find all #Rust2019 posts at [Read Rust](https://readrust.net/rust-2019/).
+
+Number: 271  Date: 2019-01-29 
+
+* [Writing an OS in Rust: Advanced paging](https://os.phil-opp.com/advanced-paging/).
+* [Embedding WebAssembly in your Rust application](https://medium.com/wasmer/executing-webassembly-in-your-rust-application-d5cd32e8ce46).
+* [Lock-free Rust: Crossbeam in 2019](https://stjepang.github.io/2019/01/29/lock-free-rust-crossbeam-in-2019.html).
+* [Performance of Rust's match vs. lookup tables](https://kevinlynagh.com/notes/match-vs-lookup/).
+* [Librsvg's GObject boilerplate is in Rust now](https://people.gnome.org/~federico/blog/librsvg-gobject-in-rust.html).
+* [Enjoy a slice of QUIC, and Rust](https://blog.cloudflare.com/enjoy-a-slice-of-quic-and-rust/). Quiche is an implementation of the QUIC transport protocol, by Cloudflare.
+* [Exporting Serde types to TypeScript](http://timryan.org/2019/01/22/exporting-serde-types-to-typescript.html).
+
+Number: 272  Date: 2019-02-05 
+
+* [Cargo's next few years](https://www.ncameron.org/blog/cargos-next-few-years/).
+* [The steps towards rustc, the great optimiser](https://kazlauskas.me/entries/the-road-to-bestest-optimiser.html).
+* [Salsa: Incremental recompilation](http://smallcultfollowing.com/babysteps/blog/2019/01/29/salsa-incremental-recompilation/).
+* [Collection of Rust hacks](https://vorner.github.io/2019/02/03/hacks.html).
+* [Writing Neovim plugins in Rust](https://medium.com/@srishanbhattarai/a-detailed-guide-to-writing-your-first-neovim-plugin-in-rust-a81604c606b1).
+* [osaka.rs - rust async without the noise](https://aep.github.io/rust-async-without-the-noise/).
+* [Rust on iOS (and Android)](https://medium.com/visly/rust-on-ios-39f799b3c1dd).
+* [Rust: regretless concurrency](https://medium.com/@polyglot_factotum/rust-regret-less-concurrency-2238b9e53333).
+* [Learning Rust via Advent of Code](https://www.forrestthewoods.com/blog/learning-rust-via-advent-of-code/).
+* [Creating web-server .deb binary with rust](https://gill.net.in/posts/creating-web-server-deb-binary-with-rust/).
+* [An introduction to the Rust programming language for Node developers](https://twitter.com/PipoPeperoni/status/1092842843637456899).
+
+Number: 273  Date: 2019-02-12 
+
+* [Learning Rust in 2019](https://www.ragona.com/posts/learning_rust_2019).
+* [A quick look at trait objects in Rust](https://tratt.net/laurie/blog/entries/a_quick_look_at_trait_objects_in_rust.html).
+* [Allocations in Rust: An introduction to the memory model](https://speice.io/2019/02/understanding-allocations-in-rust.html).
+* [Custom exit status codes with ? in main](https://www.joshmcguigan.com/blog/custom-exit-status-codes-rust/).
+* [Rust: a unique perspective](https://limpet.net/mbrubeck/2019/02/07/rust-a-unique-perspective.html).
+* [Rust on STM32: Blinking an LED](https://jonathanklimt.de/electrics/programming/rust-STM32F103-blink/).
+* [Generators I: Toward a minimum viable product](https://boats.gitlab.io/blog/post/generators-i/).
+* [Aturon retires from the Core Team (but not from Rust)](https://internals.rust-lang.org/t/aturon-retires-from-the-core-team-but-not-from-rust/9392).
+* [Rewriting stackcollapse-xdebug in Rust](https://daniellockyer.com/rewriting-stackcollapse-xdebug/).
+* [Are you still using 'println' in Rust for debugging](https://blog.knoldus.com/are-you-still-using-println-in-rust-for-debugging/)?
+* [UCG+Miri All-Hands 2019 Recap](https://www.ralfj.de/blog/2019/02/12/all-hands-recap.html).
+
+Number: 274  Date: 2019-02-19 
+
+* [Moving from Ruby to Rust](https://deliveroo.engineering/2019/02/14/moving-from-ruby-to-rust.html).
+* [Rust lifetime visualization ideas](https://blog.adamant-lang.org/2019/rust-lifetime-visualization-ideas/).
+* [Generators II: The question mark problem](https://boats.gitlab.io/blog/post/generators-ii/).
+* [A list of itch.io games written in Rust](https://itch.io/c/449652/rustlang-games).
+* [Cross-compiling Rust code to Minix](https://iandouglasscott.com/2019/02/18/cross-compiling-rust-code-to-minix/).
+* [One hundred Rust PRs later](https://phansch.net/2019/02/18/onehundred-rust-prs/).
+* [This week in Rust and WebAssembly 10](https://rustwasm.github.io/2019/02/13/this-week-in-rust-and-wasm-010.html).
+
+Number: 275  Date: 2019-02-26 
+
+* [Rust case study: Community makes Rust an easy choice for npm](https://www.rust-lang.org/static/pdfs/Rust-npm-Whitepaper.pdf).
+* [Combine results for improved Rust validation logic](https://www.joshmcguigan.com/blog/multi-try-improved-validation-logic-rust/).
+* [Rust now runs on the new Cortex-M33 based Nordic nRF9160 LTE SiP](https://twitter.com/42Technology/status/1099009843967471617).
+* [Scientific computing: a Rust adventure - part 0 - vectors](https://www.lpalmieri.com/posts/2019-02-23-scientific-computing-a-rust-adventure-part-0-vectors/).
+* [HTML code coverage reports for Rust](https://blog.knoldus.com/bid-adieu-to-tarpaulin-html-reports-are-here-for-rust/).
+* [Blockchain in Rust - a video series](https://www.youtube.com/watch?v=vJdT05zl6jk&list=PLwnSaD6BDfXL0RiKT_5nOIdxTxZWpPtAv&index=2&t=0s).
+* [Changes in the core team](https://blog.rust-lang.org/2019/02/22/Core-team-changes.html).
+* [Rust lang team working groups](http://smallcultfollowing.com/babysteps/blog/2019/02/22/rust-lang-team-working-groups/).
+* [This week in Rust and WebAssembly 11](https://rustwasm.github.io/2019/02/21/this-week-in-rust-and-wasm-011.html).
+* [The embedded WG newsletter 15](https://rust-embedded.github.io/blog/newsletter-15/).
+
+Number: 276  Date: 2019-03-05 
+
+* 🎈🎉 [Announcing Rust 1.33.0](https://blog.rust-lang.org/2019/02/28/Rust-1.33.0.html). 🎉🎈
+* [Building fast interpreters in Rust](https://blog.cloudflare.com/building-fast-interpreters-in-rust/).
+* [Implications of rewriting a browser component in Rust](https://hacks.mozilla.org/2019/02/rewriting-a-browser-component-in-rust/).
+* [24 hours of game development in Rust](http://iolivia.me/posts/24-hours-of-rust-game-dev/).
+* [Proposal: New channels for Rust's standard library](https://stjepang.github.io/2019/03/02/new-channels.html).
+* [Async-await status report](http://smallcultfollowing.com/babysteps/blog/2019/03/01/async-await-status-report/).
+* [Up and Running with React + Rust + Wasm](https://prestonrichey.com/blog/react-rust-wasm/).
+* [Exposing FFI from the Rust library](https://svartalf.info/posts/2019-03-01-exposing-ffi-from-the-rust-library/).
+* [Compile time function evaluation using `const fn` in Rust](https://blog.knoldus.com/no-more-run-time-enjoy-compile-time-function-evaluation-using-const-fn-in-rust/).
+* [This week in Rust and WebAssembly 12](https://rustwasm.github.io/2019/02/28/this-week-in-rust-and-wasm-012.html).
+
+Number: 277  Date: 2019-03-12 
+
+* [New members for the Rust core team](https://internals.rust-lang.org/t/new-members-for-the-rust-core-team/9575).
+* [Tools team changes](https://internals.rust-lang.org/t/tools-team-changes/9569).
+* [Raspberry Pi 3: Hardware debugging using JTAG](https://github.com/rust-embedded/rust-raspi3-OS-tutorials/tree/master/0B_hw_debug_JTAG).
+* [From 46s to 5s - Optimizing a 350 line raytracer in Rust](https://blog.usejournal.com/from-48s-to-5s-optimizing-a-350-line-pathtracer-in-rust-191ab4a1a412).
+* [Should Rust channels panic on send if nobody's listening](http://www.randomhacks.net/2019/03/08/should-rust-channels-panic-on-send/)?
+* [In nightly Rust, 'await!' may never return (dropping futures)](http://www.randomhacks.net/2019/03/09/in-nightly-rust-await-may-never-return/).
+* [The rise of wgpu](https://gfx-rs.github.io/2019/03/06/wgpu.html).
+* [Making a case: Rust for Python developers](https://medium.com/@rajasekar3eg/making-a-case-rust-for-python-developers-1a114e2d89f4).
+* [Intro to web programming in Rust for NodeJS developers](https://medium.com/@gruberbastian/intro-to-web-programming-in-rust-for-nodejs-developers-1a9c048c4de1).
+* [Remote development and debugging of Rust with CLion](https://medium.com/nearprotocol/remote-development-and-debugging-of-rust-with-clion-39c38ced7cc1).
+* [This week in Rust and WebAssembly 13](https://rustwasm.github.io/2019/03/07/this-week-in-rust-and-wasm-013.html).
+* [The Embedded WG newsletter 16](https://rust-embedded.github.io/blog/newsletter-16/).
+
+Number: 278  Date: 2019-03-19 
+
+* [Writing an OS in Rust: Paging implementation](https://os.phil-opp.com/paging-implementation/).
+* [Fast, bump-allocated virtual DOMs with Rust and Wasm](https://hacks.mozilla.org/2019/03/fast-bump-allocated-virtual-doms-with-rust-and-wasm/).
+* [Implementing a NES emulator in Rust](https://www.michaelburge.us/2019/03/18/nes-design.html).
+* [Porting the UNIX-like Redox OS to Arm v8.0](https://fosdem.org/2019/schedule/event/microkernel_written_in_rust/attachments/slides/3258/export/events/attachments/microkernel_written_in_rust/slides/3258/FOSDEM_2019___A_microkernel_written_in_Rust.pdf).
+* [A Rust API for librsvg](https://people.gnome.org/~federico/blog/a-rust-api-for-librsvg.html).
+* [Embedded in Rust: Implementing a static stack usage analysis tool](https://blog.japaric.io/stack-analysis/).
+* [Scientific computing: a Rust adventure (part 1 - zero-cost abstractions)](https://www.lpalmieri.com/posts/2019-03-12-scientific-computing-a-rust-adventure-part-1-zero-cost-abstractions/).
+* [Web Programming in Rust - 02/x: Deployments](https://dev.to/gruberb/web-programming-in-rust-02x-deploy-your-first-app-1k05).
+* [Announcing Governance Working Group](https://internals.rust-lang.org/t/governance-working-group-announcement/9637).
+
+Number: 279  Date: 2019-03-26 
+
+* [Why Hashbrown (Rust's new HashMap implementation) does a double-lookup on insertion](https://gankro.github.io/blah/hashbrown-insert/).
+* [Chaining functions without returning self](https://randompoison.github.io/posts/returning-self/).
+* ["Learning Rust With Entirely Too Many Linked Lists" has been updated for Rust 2018](https://rust-unofficial.github.io/too-many-lists/).
+* [Miri available as rustup component](https://www.ralfj.de/blog/2019/03/26/miri-as-rustup-component.html).
+* [How to debug Rust with Visual Studio Code](https://www.forrestthewoods.com/blog/how-to-debug-rust-with-visual-studio-code/).
+* [Rust: The hard parts - part one: References, borrowing, and ownership](https://naftuli.wtf/2019/03/20/rust-the-hard-parts/).
+* [Procedural macro in Rust 101](https://dev.to/naufraghi/procedural-macro-in-rust-101-k3f).
+* [Generalizing seqlocks: The swym algorithm](https://mtak-blog.github.io/generalizing-seqlocks).
+* [The phantom builder](https://wiredforge.com/blog/phantom-builder/index.html).
+* [Variance in Rust: An intuitive explanation](https://ehsanmkermani.com/2019/03/16/variance-in-rust-an-intuitive-explanation/).
+* [Rust All Hands 2019: Array iterators, Rayon, and more](https://developers.redhat.com/blog/2019/03/22/rust-all-hands-2019-array-iterators-rayon-and-more/).
+* [This week in Rust and WebAssembly 14](https://rustwasm.github.io/2019/03/21/this-week-in-rust-and-wasm-014.html).
+* [The Embedded WG newsletter 17](https://rust-embedded.github.io/blog/newsletter-17/).
+
+Number: 280  Date: 2019-04-02 
+
+* [Five super helpful Rust things that nobody told you about](https://saghm.github.io/five-rust-things/).
+* [RaptorQ (RFC6330) and performance optimization in Rust](https://www.cberner.com/2019/03/30/raptorq-rfc6330-rust-optimization/).
+* [Idiomatic monads in Rust](https://varkor.github.io/blog/2019/03/28/idiomatic-monads-in-rust.html).
+* [BoringTun, a userspace WireGuard implementation in Rust](https://blog.cloudflare.com/boringtun-userspace-wireguard-rust/).
+* [Understanding futures in Rust - part 1](https://www.viget.com/articles/understanding-futures-in-rust-part-1/).
+* [Mocking in Rust with conditional compilation](https://klausi.github.io/rustnish/2019/03/31/mocking-in-rust-with-conditional-compilation.html).
+* [Face detection with Tensorflow Rust](https://cetra3.github.io/blog/face-detection-with-tensorflow-rust/).
+* [DSL in Rust: Challenges](https://blog.yoshuawuyts.com/2019-03-03-dsls-2/).
+* [Explained: How does async work in Rust](https://dev.to/gruberb/explained-how-does-async-work-in-rust-46f8)?
+* [This week in Rust and WebAssembly 15](https://rustwasm.github.io/2019/03/28/this-week-in-rust-and-wasm-015.html).
+
+Number: 281  Date: 2019-04-09 
+
+* [Rust is the most loved language four years in a row](https://insights.stackoverflow.com/survey/2019#most-loved-dreaded-and-wanted).
+* [How to compose functions in Rust](https://stackoverflow.com/questions/45786955/how-to-compose-functions-in-rust).
+* [A basic web application with Rust and Actix-web](https://zupzup.org/rust-webapp/).
+* [More tricks up in the ArcSwap’s sleeve](https://vorner.github.io/2019/04/06/tricks-in-arc-swap.html).
+* [Arenas vs. indices](https://llogiq.github.io/2019/04/06/arena.html).
+* [Protocols in Tokio (i3 IPC)](https://leshow.github.io/post/impl_proto_tokio/).
+* [Array1 and function traits (scientific computing: a Rust adventure, part 2)](https://www.lpalmieri.com/posts/2019-04-07-scientific-computing-a-rust-adventure-part-2-array1/).
+
+Number: 282  Date: 2019-04-16 
+
+* 🎈🎉 [Announcing Rust 1.34.0](https://blog.rust-lang.org/2019/04/11/Rust-1.34.0.html). 🎉🎈
+* [ripgrep 11 released](https://github.com/BurntSushi/ripgrep/releases/tag/11.0.0).
+* [Introducing Runtime, a platform-agnostic library that intends to make Async Rust both flexible and easy](https://blog.yoshuawuyts.com/runtime/).
+* [A love letter to Rust macros](https://happens.lol/posts/a-love-letter-to-rust-macros/).
+* [Rust: beyond the typechecker](http://blog.merigoux.fr/en/2019/04/16/verifying-rust.html).
+* [Face detection with Actix web](https://cetra3.github.io/blog/face-detection-with-actix-web/).
+* [Compiler team needs more than coders](http://smallcultfollowing.com/babysteps/blog/2019/04/15/more-than-coders/).
+* [for await loops (Part I)](https://boats.gitlab.io/blog/post/for-await-i/).
+* [Keeping Rust projects' README.md code examples up-to-date](https://blog.guillaume-gomez.fr/articles/2019-04-13+Keeping+Rust+projects%27+README.md+code+examples+up-to-date).
+* [Making an iterator from a function](https://weblog.latte.ca/blake/tech/rust/makingiterators.html).
+* [cargo-call-stack, part 2: getting call graph information from rustc](https://blog.japaric.io/stack-analysis-2/).
+* [Web development with Rust — 03/x: Create a REST API](https://dev.to/gruberb/web-development-with-rust-03-x-create-a-rest-api-3i82).
+* [Building a pub/sub server with Sonr](https://hagsteel.com/posts/building-a-pub-sub-with-sonr-part-1/).
+
+Number: 283  Date: 2019-04-23 
+
+* [Rust's 2019 roadmap](https://blog.rust-lang.org/2019/04/23/roadmap.html).
+* [Amethyst receives Mozilla grant for WASM development](https://www.amethyst.rs/blog/moss-grant-announce/).
+* [6 useful Rust macros that you might not have seen before](https://medium.com/@benmcdonald_11671/6-useful-rust-macros-that-you-might-not-have-seen-before-59d1386f7bc5).
+* [Learning parser combinators with Rust](https://bodil.lol/parser-combinators/).
+* [What not to do in Rust](https://blog.sentry.io/2018/04/05/you-cant-rust-that).
+* [Generic returns in Rust](https://blog.jcoglan.com/2019/04/22/generic-returns-in-rust/).
+* [Futures 0.1 compatibility layer](https://rust-lang-nursery.github.io/futures-rs/blog/2019/04/18/compatibility-layer.html).
+* [What I learned from my failed attempt of writing baremetal android in Rust](https://onatm.dev/2019/04/22/what-i-learned-from-my-failed-attempt-of-writing-baremetal-android-in-rust/).
+* [Building a plugin system using Rust and Wasmer](https://wiredforge.com/blog/wasmer-plugin-pt-1) ([part 2](https://wiredforge.com/blog/wasmer-plugin-pt-2), [part 3](https://wiredforge.com/blog/wasmer-plugin-pt-3/index.html)).
+* [Using DMA to transfer data with embedded Rust](https://flowdsp.io/blog/stm32f3-02-dac-dma/).
+* [AiC: Adventures in consensus](http://smallcultfollowing.com/babysteps/blog/2019/04/19/aic-adventures-in-consensus/).
+* [rustup 1.18.0 released](https://github.com/rust-lang/rustup.rs/blob/master/CHANGELOG.md#1180---2019-04-22).
+* [RustFest 2019 - next stop: Barcelona](https://blog.rustfest.eu/next-stop-barcelona).
+* [Videos from Rust Latam 2019](https://www.youtube.com/playlist?list=PL85XCvVPmGQjuWUNeFCgl8X2EOC_aAq5N).
+
+Number: 284  Date: 2019-04-30 
+
+* 🎈🎉 [Announcing Rust 1.34.1](https://blog.rust-lang.org/2019/04/25/Rust-1.34.1.html). 🎉🎈
+* [Await syntax discussion summary](https://internals.rust-lang.org/t/await-syntax-discussion-summary/9914).
+* [A (type-based) Rust cheatsheet](https://upsuper.github.io/rust-cheatsheet/).
+* [Writing an OS in Rust: Testing](https://os.phil-opp.com/testing/).
+* [How Rust solved dependency hell](https://stephencoakley.com/2019/04/24/how-rust-solved-dependency-hell).
+* [Creating crossplatform Rust terminal apps](http://www.jonathanturner.org/2019/04/porting-the-pikachu.html).
+* [10 key learnings in Rust after 30,000 lines of code](https://medium.com/@jondot/my-key-learnings-after-30-000-loc-in-rust-a553e6403c19).
+* [UWP port is in progress](https://www.reddit.com/r/rust/comments/bhffwn/uwp_port_is_in_progress/).
+* [Mozilla IRC sunset and the Rust channel](https://blog.rust-lang.org/2019/04/26/Mozilla-IRC-Sunset-and-the-Rust-Channel.html).
+* [Giving up on wlroots-rs](http://way-cooler.org/blog/2019/04/29/rewriting-way-cooler-in-c.html).
+* [Making Sandspiel (a falling sand game in Rust and Wasm)](https://maxbittker.com/making-sandspiel).
+* [Implementing tile encoding in rav1e](https://blog.rom1v.com/2019/04/implementing-tile-encoding-in-rav1e/).
+* [Stacked Borrows 2](https://www.ralfj.de/blog/2019/04/30/stacked-borrows-2.html) with more precise tracking of shared references.
+
+Number: 285  Date: 2019-05-07 
+
+* [A final proposal for await syntax](https://boats.gitlab.io/blog/post/await-decision/).
+* [Cargo in 2019](https://www.ncameron.org/blog/cargo-in-2019/).
+* [Const generics: a summary of progress so far](https://github.com/rust-lang/rust/issues/44580#issuecomment-488819344).
+* [Rust parallelism for non-C/C++ developers](https://medium.com/nearprotocol/rust-parallelism-for-non-c-c-developers-ec23f48b7e56).
+* [Writing an OS in Rust: Updates in April 2019](https://os.phil-opp.com/status-update/2019-05-01/).
+* [A guide to Rust graphics libraries as of 2019](https://wiki.alopex.li/AGuideToRustGraphicsLibraries2019).
+* [World's first private Cargo registry](https://blog.cloudsmith.io/2019/05/01/worlds-first-private-cargo-registry/).
+* [Compile-time coprocessor codegen, with Rust macros](https://guiand.xyz/blog-posts/macro-assembly-codegen.html).
+* [Using Wasmer for plugins part 4](https://wiredforge.com/blog/wasmer-plugin-pt-4/index.html)
+
+Number: 286  Date: 2019-05-14 
+
+* 🎈🎉 [Announcing Rust 1.34.2](https://blog.rust-lang.org/2019/05/14/Rust-1.34.2.html). 🎉🎈
+* [Security advisory for the standard library](https://blog.rust-lang.org/2019/05/13/Security-advisory.html).
+* [Update on the CI investigation](https://internals.rust-lang.org/t/update-on-the-ci-investigation/10056).
+* [2D graphics on modern GPU](https://raphlinus.github.io/rust/graphics/gpu/2019/05/08/modern-2d.html).
+* [Rust patterns: enums instead of booleans](http://blakesmith.me/2019/05/07/rust-patterns-enums-instead-of-booleans.html).
+* [Asymmetric multi-processing on microcontrollers with μAMP](https://blog.japaric.io/microamp/).
+* [State of machine learning in Rust](https://ehsanmkermani.com/2019/05/13/state-of-machine-learning-in-rust/).
+
+Number: 287  Date: 2019-05-21 
+
+* [4 years of Rust](https://blog.rust-lang.org/2019/05/15/4-Years-Of-Rust.html).
+* [The 2019 Rust event lineup](https://blog.rust-lang.org/2019/05/20/The-2019-Rust-Event-Lineup.html).
+* [Understanding zero cost abstractions](https://boats.gitlab.io/blog/post/zero-cost-abstractions/).
+* [Using Rust to scale Elixir for 11 million concurrent users](https://blog.discordapp.com/using-rust-to-scale-elixir-for-11-million-concurrent-users-c6f19fc029d3).
+* [Rust in Avast](https://vorner.github.io/2019/05/19/rust-in-avast.html).
+* [Evaluating pipelined rustc compilation](https://internals.rust-lang.org/t/evaluating-pipelined-rustc-compilation/10199).
+* [Analysis of various tricky Rust code](https://github.com/dtolnay/case-studies).
+* [Get back some compile time from monomorphization](https://llogiq.github.io/2019/05/18/momo.html).
+* [mem::uninitialized is deprecated](https://gankro.github.io/blah/initialize-me-maybe/).
+* [Shell completions in pure Rust](https://www.joshmcguigan.com/blog/shell-completions-pure-rust/).
+* [Creating C/C++ APIs in Rust](https://karroffel.gitlab.io/post/2019-05-15-rust/).
+* [How to start Rust chat app](https://medium.com/@steadylearner/how-to-start-rust-chat-app-499a194d0820).
+* [WebRender MVP ships in Firefox](https://mozillagfx.wordpress.com/2019/05/21/graphics-team-ships-webrender-mvp/).
+* [Rust in Motion](https://www.manning.com/livevideo/rust-in-motion) - a video series by Carol Nichols and Jake Goulding (requires purchase).
+* [Rust in Action](https://www.manning.com/books/rust-in-action) - a book by Tim McNamara (early access, requires purchase).
+
+Number: 288  Date: 2019-05-28 
+
+* 🎈🎉 [Announcing Rust 1.35.0](https://blog.rust-lang.org/2019/05/23/Rust-1.35.0.html). 🎉🎈
+* [Update on await syntax](https://boats.gitlab.io/blog/post/await-decision-ii/).
+* [Writing a compiler in Rust](http://thume.ca/2019/04/18/writing-a-compiler-in-rust/).
+* [Announcing Mockiato - A strict, yet friendly mocking library for Rust 2018](https://blog.myelin.ch/2019/05/24/mockiato-announcement.html).
+* [Programming Servo: Zen and the art of removing blocks from your system](https://medium.com/@polyglot_factotum/programming-servo-zen-and-the-art-of-removing-blocks-from-your-system-51c1b7d404e3).
+* [Cross compiling and statically linking against Rust libraries](https://medium.com/csis-techblog/cross-compiling-and-statically-linking-against-rust-libraries-2c02ee2c01af).
+* [Rebuffing the attack of the clones - a newbie's guide to `clone`](https://thenewwazoo.github.io/clone.html).
+* [New Rustacean Meta 3](https://newrustacean.com/show_notes/meta/_3/) - A story and a dream (and the promise of Rust): the final episode of New Rustacean!
+* [Erebor](http://erebor.io), a Rust consultancy startup by [Alexander Regueiro](https://github.com/alexreg).
+
+Number: 289  Date: 2019-06-04 
+
+* [Writing an OS in Rust: Updates in May 2019](https://os.phil-opp.com/status-update/2019-06-03/).
+* [Unsafe Code Guidelines Reference now available online](https://rust-lang.github.io/unsafe-code-guidelines/).
+* [Actix-web 1.0 released](https://github.com/actix/actix-web/blob/master/CHANGES.md).
+* [j4rs - calling Java code from Rust](https://astonbitecode.github.io/blog/post/j4rs_0.6.0/).
+* [The Governance WG is going public](https://blog.rust-lang.org/2019/06/03/governance-wg-announcement.html).
+* [Bzip2 in Rust - basic infrastructure and CRC32 computation](https://people.gnome.org/~federico/blog/bzip2-in-rust-basic-infra.html).
+* [Evoli - an official Amethyst showcase game](https://amethyst.rs/posts/evoli-an-official-amethyst-showcase-game).
+* [Poking the macOS IO Kit with Rust](https://svartalf.info/posts/2019-05-31-poking-the-macos-io-kit-with-rust/).
+
+Number: 290  Date: 2019-06-11 
+
+* [Sealed Rust - A plan to bring Rust to safety critical software domains](https://ferrous-systems.com/blog/sealed-rust-the-pitch/).
+* [Embedded WG: Embedded Rust in 2019](https://rust-embedded.github.io/blog/embedded-rust-in-2019/).
+* [Nannou update - Vulkan, LASERs and more](https://nannou.cc/posts/nannou_v0.9).
+* [Bzip2 to see revival under new maintainership, experimental porting to Rust](https://www.phoronix.com/scan.php?page=news_item&px=Bzip2-Revival-2019).
+* [Auth web microservice with Rust using actix-web 1.0 - complete tutorial](https://gill.net.in/posts/auth-microservice-rust-actix-web1.0-diesel-complete-tutorial/).
+* [How to use gtk-rs on Windows using the MSVC toolchain](https://www.reddit.com/r/rust/comments/bzkhmt/how_to_use_gtkrs_on_windows_using_the_msvc/).
+* [Hosting embedded Rust apps on Apache Mynewt with STM32 Blue Pill](https://medium.com/@ly.lee/hosting-embedded-rust-apps-on-apache-mynewt-with-stm32-blue-pill-c86b119fe5f?sk=f58f4cf6c608fded4b354063e474a93b).
+* [Speeding up builds and managing versions](https://estada.ch/2019/6/7/rusts-hidden-talents/).
+
+Number: 291  Date: 2019-06-18 
+
+* [gfx-rs: 5 year anniversary](https://gfx-rs.github.io/2019/06/12/anniversary-5.html).
+* [Green threads explained in 200 lines of Rust](https://cfsamson.gitbook.io/green-threads-explained-in-200-lines-of-rust/).
+* [Facebook's new cryptocurrency Libra uses Rust](https://developers.libra.org/docs/community/coding-guidelines).
+* [Vimeo introduces support for AV1 using rav1e, a Rust library](https://press.vimeo.com/61553-vimeo-introduces-support-for-royalty-free-video-codec-av1).
+* [Amethyst v0.11.0 released, now supporting gfx-hal with Rendy](https://amethyst.rs/posts/release-0-11).
+* [Bzip2 in Rust: porting the randomization table](https://people.gnome.org/~federico/blog/bzip2-in-rust-randomization-table.html).
+* [Building secure systems using RISC-V and Rust](https://content.riscv.org/wp-content/uploads/2019/06/14.05-building_secure_systems-1.pdf).
+
+Number: 292  Date: 2019-06-25 
+
+* [nom parser combinators 5.0 release: replace macros with functions, better errors](http://unhandledexpression.com/general/2019/06/17/nom-5-is-here.html).
+* [The typestate pattern in Rust](http://cliffle.com/blog/rust-typestate/).
+* [Implementing ptrace for Redox OS - part 0](https://www.redox-os.org/news/rsoc-ptrace-0/).
+* [Let's build a JavaScript engine (in Rust)](https://2019.jsconf.eu/jason-williams/lets-build-a-javascript-engine.html).
+* [Real Time for the Masses (RTFM) goes multi-core](https://blog.japaric.io/multicore-rtfm/).
+* [Rust streams](https://blog.yoshuawuyts.com/rust-streams/).
+* [Rust on the ESP32/ESP8266 and how to get started](https://dentrassi.de/2019/06/16/rust-on-the-esp-and-how-to-get-started/).
+* [Rust for closed-source projects](https://ntcore.com/?p=641).
+* [swym: Are we lock-free yet](https://mtak-blog.github.io/are-we-lock-free-yet)?
+
+Number: 293  Date: 2019-07-02 
+
+* [Writing an OS in Rust: Heap allocation](https://os.phil-opp.com/heap-allocation/).
+* [Non-lexical lifetimes arrives for everyone](http://blog.pnkfx.org/blog/2019/06/26/breaking-news-non-lexical-lifetimes-arrives-for-everyone/).
+* [Status of rust-analyzer: Achievements and Open Collective](https://ferrous-systems.com/blog/rust-analyzer-status-opencollective/).
+* [TLS performance: rustls versus OpenSSL](https://jbp.io/2019/07/01/rustls-vs-openssl-performance.html).
+* [Optimizing jieba-rs to be 33% faster than cppjieba](https://blog.paulme.ng/posts/2019-06-30-optimizing-jieba-rs-to-be-33percents-faster-than-cppjieba.html).
+* [Brave improves its ad-blocker performance by 69x with new engine implementation in Rust](https://brave.com/improved-ad-blocker-performance/).
+* [Writing a small ray tracer in Rust and Zig](https://nelari.us/post/raytracer_with_rust_and_zig/).
+* [Compiling Rust apps for Termux with nix-shell](https://blog.geemili.xyz/blog/rust-app-on-termux-with-nix/).
+* [Building crates so they look like C(ABI) libraries](https://dev.to/luzero/building-crates-so-they-look-like-c-abi-libraries-1ibn).
+
+Number: 294  Date: 2019-07-09 
+
+* 🎈🎉 [Announcing Rust 1.36.0](https://blog.rust-lang.org/2019/07/04/Rust-1.36.0.html). 🎉🎈
+* [Async-await status report #2](http://smallcultfollowing.com/babysteps/blog/2019/07/08/async-await-status-report-2/).
+* [Writing an OS in Rust: Updates in June 2019](https://os.phil-opp.com/status-update/2019-06-04/).
+* [Method for emulating higher-kinded types in Rust](https://gist.github.com/edmundsmith/855fcf0cb35dd467c29a9350481f0ecf).
+* [Speedy desktop apps with GTK and Rust](https://nora.codes/tutorial/speedy-desktop-apps-with-gtk-and-rust/).
+* [Build a decentralized chat using JavaScript & Rust (WebAssembly)](https://medium.com/perlin-network/build-a-decentralized-chat-using-javascript-rust-webassembly-c775f8484b52).
+* [Safer, simpler embedded Rust with Apache Mynewt](https://medium.com/@ly.lee/safer-simpler-embedded-rust-with-apache-mynewt-on-stm32-blue-pill-d8fcb41969ac).
+
+Number: 295  Date: 2019-07-16 
+
+* [Microsoft Security Response Center endorses the use of Rust for safe systems programming](https://msrc-blog.microsoft.com/2019/07/16/a-proactive-approach-to-more-secure-code/).
+* [How to speed up the Rust compiler in 2019](https://blog.mozilla.org/nnethercote/2019/07/17/how-to-speed-up-the-rust-compiler-in-2019/).
+* ["What the hardware does" is not what your program does: Uninitialized memory](https://www.reddit.com/r/rust/comments/cd522f/what_the_hardware_does_is_not_what_your_program/).
+* [What is Rust's unsafe](https://nora.codes/post/what-is-rusts-unsafe/)?
+* [AiC: Unbounded queues and lang design](http://smallcultfollowing.com/babysteps/blog/2019/07/10/aic-unbounded-queues-and-lang-design/).
+* [Creating a simple LISP in Rust](https://willspeak.me/2019/07/10/lisp-in-two-days-with-rust.html).
+* [Announcing Rustacean Station and Rust 1.36](https://rustacean-station.org/episode/000-rust-1.36.0/).
+* [Rust as the new C. Part 1: building and combining native libs into C API](http://hotforknowledge.com/2019/07/14/6-rust-the-new-c/).
+* [New tools for 2D game development](https://amethyst.rs/posts/tools-for-2d-games).
+* [Fullstack Rust with Yew](https://www.steadylearner.com/blog/read/Fullstack-Rust-with-Yew).
+* [gfx-rs Javelin project kick-off](https://gfx-rs.github.io/2019/07/13/javelin.html).
+* [Visual programming in embedded Rust with Apache Mynewt and Google Blockly](https://medium.com/@ly.lee/visual-programming-with-embedded-rust-yes-we-can-with-apache-mynewt-and-google-blockly-8b67ef7412d7).
+* [Stream combinators implemented using for await syntax](https://www.reddit.com/r/rust/comments/cbvhq9/stream_combinators_implemented_using_for_await/).
+* [Ferrous Systems: Rust Summer Classes in Berlin](https://ferrous-systems.com/blog/rust-summer-classes/).
+* [Tickets are now available RustFest Barcelona - 9-12 November 2019](https://blog.rustfest.eu/barcelona-announcement).
+
+Number: 296  Date: 2019-07-23 
+
+* [U.S. House Committee on Financial Services hearing: Why was the Rust language chosen](https://www.c-span.org/video/?c4808083/rust-language-chosen)?
+* [Microsoft Security Response Center: Why Rust for safe systems programming](https://msrc-blog.microsoft.com/2019/07/22/why-rust-for-safe-systems-programming/).
+* [Compiler speed has improved 30-40% across the board year-to-date, with some projects seeing 45%+ improvements](https://www.reddit.com/r/rust/comments/cezxjn/compiler_speed_has_improved_3040_across_the_board/).
+* [Perils of constructors](https://matklad.github.io/2019/07/16/perils-of-constructors.html).
+* [Notes on a smaller Rust](https://boats.gitlab.io/blog/post/notes-on-a-smaller-rust/).
+* [Announcing heim project](https://svartalf.info/posts/2019-07-17-announcing-heim-project/).
+* [Gotham — from start to Heroku](https://blog.codeship.com/gotham-from-start-to-heroku/).
+* [How to write full stack Rust code](https://www.steadylearner.com/blog/read/How-to-write-Full-Stack-Rust-code).
+* [HOWTO: Replace mem::uninitialized with mem::MaybeUninit](https://www.reddit.com/r/rust/comments/cefgec/howto_replace_memuninitialized_with_memmaybeuninit/).
+* [Stream combinators implemented using for await syntax](https://www.reddit.com/r/rust/comments/cbvhq9/stream_combinators_implemented_using_for_await/).
+* [CLion Rust plugin adds a new experimental macro expansion engine](https://www.jetbrains.com/clion/whatsnew/#v2019-2-rust).
+
+Number: 297  Date: 2019-07-30 
+
+* [The Rust compiler is still getting faster](https://blog.mozilla.org/nnethercote/2019/07/25/the-rust-compiler-is-still-getting-faster/).
+* [Unsafe as a human-assisted type system](https://matklad.github.io/2019/07/25/unsafe-as-a-type-system.html).
+* [Why does the Rust compiler not optimize code assuming that two mutable references cannot alias](https://stackoverflow.com/questions/57259126/why-does-the-rust-compiler-not-optimize-code-assuming-that-two-mutable-reference)?
+* [Python vs Rust for neural networks](https://ngoldbaum.github.io/posts/python-vs-rust-nn/).
+* [Dependency management and trust scaling](http://lucumr.pocoo.org/2019/7/29/dependency-scaling/).
+
+Number: 298  Date: 2019-08-06 
+
+* [We rewrote our IoT platform in Rust and got away with it](https://medium.com/dwelo-r-d/we-rewrote-our-iot-platform-in-rust-and-got-away-with-it-2c8867c61b67).
+* [About the future of nphysics: a pure rust 2D and 3D real-time physics engine](https://www.patreon.com/posts/28917514).
+* [Building GTK+ app in Rust for a first time](https://turbomack.github.io/posts/2019-07-28-rust-vs-gui.html).
+* [Understanding Rust through AVL trees](https://francismurillo.github.io/2019-07-31-Understanding-Rust-Through-AVL-Trees/).
+* [Writing an OS in Rust: Updates in July 2019](https://os.phil-opp.com/status-update/2019-08-02/).
+* [Rust reverses research ruin](https://medium.com/@me_26124/rust-reverses-research-ruin-88641c11a99f).
+* [Veloren: A multiplayer voxel RPG written in Rust](https://veloren.net/welcome/).
+* [Minimum safe abstractions](https://llogiq.github.io/2019/08/01/unsafe.html).
+* [How to serve static files with Rust](https://www.steadylearner.com/blog/read/How-to-serve-static-files-with-Rust).
+* [Rust Rocks NB-IoT! STM32 Blue Pill with Quectel BC95-G on Apache Mynewt](https://medium.com/@ly.lee/rust-rocks-nb-iot-stm32-blue-pill-with-quectel-bc95-g-on-apache-mynewt-ef62a7e28f7e?sk=aaa21371f68a07c543066b6b89a760f0).
+
+Number: 299  Date: 2019-08-13 
+
+* [Tokio alpha release with async & await](https://tokio.rs/blog/2019-08-alphas/).
+* [Await a minute, why bother](https://docs.rs/dtolnay/0.0.5/dtolnay/macro._01__await_a_minute.html)?
+* [Functional programming jargon in Rust](https://functional.works-hub.com/learn/functional-programming-jargon-in-rust-1b555).
+* [Migrating the TiKV Rust client from futures 0.1 to 0.3](https://tikv.org/blog/client-futures/).
+* [Updating to async/await](https://leshow.github.io/post/async_await/).
+* [Follow-up to Method on Emulating Higher-Kinded Types (HKTs) in Rust](https://gist.github.com/edmundsmith/e09d5f473172066c0023ef84ee830cad).
+* [Runtime configuration reloading](https://vorner.github.io/2019/08/11/runtime-configuration-reloading.html).
+* [Parsing Rust strings into slices](https://wduquette.github.io/parsing-strings-into-slices).
+* [Why is there a large performance impact when looping over an array over 240 elements](https://stackoverflow.com/questions/57458460/)?
+
+Number: 300  Date: 2019-08-20 
+
+* 🎈🎉 [Announcing Rust 1.37.0](https://blog.rust-lang.org/2019/08/15/Rust-1.37.0.html). 🎉🎈
+* [Announcing async-std beta: an async port of the Rust standard library](https://async.rs/blog/announcing-async-std/).
+* [How Rust optimizes async/await: Part 1](https://tmandry.gitlab.io/blog/posts/optimizing-await-1/).
+* [System 76 releases new GTK firmware manager written in Rust](https://blog.system76.com/post/187072707563/the-new-firmware-manager-updating-firmware-across).
+* [Writing a Linux kernel module in Rust](https://github.com/lizhuohua/linux-kernel-module-rust).
+* [Introducing the Rust Game Development Working Group](https://rust-gamedev.github.io/2019/08/18/introducing-the-rust-game-development-working-group).
+* [Steam wishlist announced for Way of Rhea, a sidescrolling puzzle game written in Rust](https://store.steampowered.com/app/1110620/Way_of_Rhea/).
+* [Visual embedded Rust programming with Visual Studio Code](https://medium.com/@ly.lee/visual-embedded-rust-programming-with-visual-studio-code-1bc1262e398c?source=friends_link&sk=222de63e45993aacd0db5a2e4b1f33c7).
+* [How to diagnose async apps with `tracing`](https://tokio.rs/blog/2019-08-tracing/).
+* [Using C libraries in Rust: A practical guide to FFI using bindgen](https://medium.com/dwelo-r-d/using-c-libraries-in-rust-13961948c72a).
+* [Pre-/Post-conf events: Sustainable 🚄 train travels from and to RustFest Barcelona](https://blog.rustfest.eu/pre-post-conf-events-sustainable-train-travels).
+* [`<_>::v::<_>` - A fun little piece of Rust artwork](https://chrismorgan.info/blog/rust-artwork-owl/).
+
+Number: 301  Date: 2019-08-27 
+
+* [Should small Rust structs be passed by-copy or by-borrow](https://www.forrestthewoods.com/blog/should-small-rust-structs-be-passed-by-copy-or-by-borrow/)?
+* [Thoughts on Rust bloat](https://raphlinus.github.io/rust/2019/08/21/rust-bloat.html).
+* [Rust GUI ecosystem overview](https://gitlab.com/z0mbie42/rust_gui_ecosystem_overview).
+* [Introduction to C2Rust](https://immunant.com/blog/2019/08/introduction-to-c2rust/).
+* [Async stack traces in Rust](http://fitzgeraldnick.com/2019/08/27/async-stacks-in-rust.html).
+* [Polsim - a case study for small-scale scientific computing in Rust](https://tinkering.xyz/polsim/).
+* [Managing memory in Rust: Entity-component systems](https://mmstick.keybase.pub/managing-memory-in-rust-ecs/).
+* [Actually using Crev, or, the problem of trusting software dependencies](https://wiki.alopex.li/ActuallyUsingCrev).
+* [Review of “Everything in Rust” of COSCUP 2019](https://medium.com/coding-neutrino-blog/review-of-everything-in-rust-of-coscup-2019-54152467d1c6).
+
+Number: 302  Date: 2019-09-03 
+
+* [Introduction to Rust web applications](https://erwabook.com/intro/).
+* [This month in Rust GameDev #1 - August 2019](https://rust-gamedev.github.io/2019/09/02/newsletter-001.html).
+* [HHVM is rewriting some of its OCaml code to Rust](https://hhvm.com/blog/2019/08/27/hhvm-4.20.0.html).
+* [Announcing cargo-udeps](https://gist.github.com/est31/3d9e880be746c3a443c699d9ff1888d2).
+* [Announcing structopt 0.3](https://www.reddit.com/r/rust/comments/cxgw86/announcing_structopt_03/).
+* [Semantic validation in Rust](https://slowtec.de/posts/2019-09-03-semantic-validation-with-rust.html).
+* [Low power NB-IoT on STM32 Blue Pill with Apache Mynewt and embedded Rust](https://medium.com/@ly.lee/low-power-nb-iot-on-stm32-blue-pill-with-apache-mynewt-and-embedded-rust-cef5a3ecdd90).
+
+Number: 303  Date: 2019-09-10 
+
+* [How Rust optimizes async/await II: program analysis](https://tmandry.gitlab.io/blog/posts/optimizing-await-2/).
+* [Rust on the ESP32](https://mabez.dev/blog/posts/esp32-rust/).
+* [Linux.Fe2O3: a Rust virus](https://www.guitmz.com/linux-fe2o3-rust-virus/).
+* [Improvement to the compile time of a crate](http://antoyo.ml/compilation-time-dependencies).
+* [hyper 0.13 alpha supports async/await](https://seanmonstar.com/post/187493499882/hyper-alpha-supports-asyncawait).
+* [Writing an OS in Rust: updates in August 2019](https://os.phil-opp.com/status-update/2019-09-09/).
+* [Rust in large organizations - meeting notes](https://users.rust-lang.org/t/rust-in-large-organizations-meeting/32059).
+* [Futures concurrency](https://blog.yoshuawuyts.com/futures-concurrency/).
+
+Number: 304  Date: 2019-09-17 
+
+* [Upcoming docs.rs changes](https://blog.rust-lang.org/2019/09/18/upcoming-docsrs-changes.html).
+* [GitHub Actions for Rust](https://svartalf.info/posts/2019-09-16-github-actions-for-rust/).
+* [Rustconf 2019 videos](https://www.youtube.com/playlist?list=PL85XCvVPmGQhDOUIZBe6u388GydeACbTt).
+* [Improved C variadics in Rust and C2Rust](https://immunant.com/blog/2019/09/variadics/).
+* [Oreboot: Coreboot minus C, a talk by Google](https://osfc.io/uploads/talk/paper/23/Oreboot.pdf).
+* [Announcing awesome-rust-mentors](https://rustbeginners.github.io/awesome-rust-mentors/).
+* [Adventures in motion control](http://adventures.michaelfbryan.com/posts/announcing-adventures-in-motion-control/).
+
+Number: 305  Date: 2019-09-24 
+
+* [LLVM: closing the gap - cross-language LTO between Rust and C/C++](http://blog.llvm.org/2019/09/closing-gap-cross-language-lto-between.html).
+* [Weld: accelerating numpy, scikit and pandas as much as 100x with Rust and LLVM](https://notamonadtutorial.com/weld-accelerating-numpy-scikit-and-pandas-as-much-as-100x-with-rust-and-llvm-12ec1c630a1).
+* [Declarative memory management](https://amos.me/blog/2019/declarative-memory-management/).
+* [Generic newtypes: A way to work around the orphan rule](https://blog.eizinger.io/8593/generic-newtypes-a-way-to-work-around-the-orphan-rule).
+* [Async builders](https://blog.yoshuawuyts.com/async-finalizers/).
+* [Adventures in motion control: top-level infrastructure](http://adventures.michaelfbryan.com/posts/top-level-infrastructure/).
+* [Build an NB-IoT GPS Tracker on STM32 L476 with Apache Mynewt and Embedded Rust](https://medium.com/@ly.lee/build-an-nb-iot-gps-tracker-on-stm32-l476-with-apache-mynewt-and-embedded-rust-8c095a925546).
+* [Navigating the Rust OSS community](https://yaah.dev/getting-involved).
+
+Number: 306  Date: 2019-10-01 
+
+* 🎈🎉 [Announcing Rust 1.38.0](https://blog.rust-lang.org/2019/09/26/Rust-1.38.0.html). 🎉🎈
+* [Security advisory for Cargo](https://blog.rust-lang.org/2019/09/30/Security-advisory-for-cargo.html).
+* [Async-await hits beta](https://blog.rust-lang.org/2019/09/30/Async-await-hits-beta.html).
+* [Accurate mental model for Rust's reference types](https://docs.rs/dtolnay/0.0.6/dtolnay/macro._02__reference_types.html).
+* [Fighting the Async fragmentation](https://vorner.github.io/2019/09/29/figthting-the-async-fragmentation.html).
+* [Making a RISC-V Operating System using Rust](http://web.eecs.utk.edu/~smarz1/osblog/).
+* [Plugins in Rust](http://adventures.michaelfbryan.com/posts/plugins-in-rust/).
+* [Building the Azure IoT Edge Security Daemon in Rust](https://msrc-blog.microsoft.com/2019/09/30/building-the-azure-iot-edge-security-daemon-in-rust/).
+* [Adventures in motion control: FPS counter](http://adventures.michaelfbryan.com/posts/fps-counter/).
+* [Causal profiling Rust code](https://llogiq.github.io/2019/09/25/coz.html).
+* [gfx-rs 2019 update](https://gfx-rs.github.io/2019/10/01/update.html).
+* [Announcing Drone OS - an embedded operating system for writing real-time applications in Rust](https://www.reddit.com/r/rust/comments/d999qo/announcing_drone_os_010/).
+
+Number: 307  Date: 2019-10-08 
+
+* [Announcing the Inside Rust blog](https://blog.rust-lang.org/2019/10/03/inside-rust-blog.html).
+* [Async Foundations update: Time for polish](https://blog.rust-lang.org/inside-rust/2019/10/07/AsyncAwait-WG-Focus-Issues.html).
+* [Keeping Rust projects secure with cargo-audit 0.9: dependency trees, core advisories, unmaintained crates](https://blog.rust-lang.org/inside-rust/2019/10/03/Keeping-secure-with-cargo-audit-0.9.html).
+* [Designing a COM library for Rust](https://msrc-blog.microsoft.com/2019/10/08/designing-a-com-library-for-rust/).
+* [Tonic: gRPC has come to async/await](https://luciofran.co/tonic-grpc-has-come-to-async-await/).
+* [reqwest alpha with async/await released](https://seanmonstar.com/post/188220739932/reqwest-alphaawait).
+* [Writing an OS in Rust - updates in September 2019](https://os.phil-opp.com/status-update/2019-10-06/).
+* [Static Assertions 1.0 is released](https://nikolaivazquez.com/posts/programming/rust-static-assertions-1_0/).
+* [Ownership and impl Trait](https://tech.fpcomplete.com/rust/ownership-and-impl-trait).
+* [Writing an HTTP server in Rust (part 1)](https://curiosityoverflow.xyz/posts/linda/).
+* [Adventures in motion control: The communications system part 1](http://adventures.michaelfbryan.com/posts/comms-part-1/).
+* [Coding nRF52 with Rust and Apache Mynewt on Visual Studio Code](https://medium.com/@ly.lee/coding-nrf52-with-rust-and-apache-mynewt-on-visual-studio-code-9521bcba6004).
+* [This month in Rust GameDev 2 - September 2019](https://rust-gamedev.github.io/2019/10/05/newsletter-002.html).
+* [The Embedded Working Group newsletter 19](https://rust-embedded.github.io/blog/newsletter-19/).
+* [Rust now has more than 100000 commits](https://github.com/rust-lang/rust).
+* [pdf] [Leveraging Rust types for modular specification and verification](http://pm.inf.ethz.ch/publications/getpdf.php?bibname=Own&id=AstrauskasMuellerPoliSummers19b.pdf).
+
+Number: 308  Date: 2019-10-15 
+
+* [Making the Tokio scheduler 10x faster](https://tokio.rs/blog/2019-10-scheduler/).
+* [How to speed up the Rust compiler some more in 2019](https://blog.mozilla.org/nnethercote/2019/10/11/how-to-speed-up-the-rust-compiler-some-more-in-2019/).
+* [The node experiment - exploring async basics with Rust](https://cfsamson.github.io/book-exploring-async-basics/).
+* [Debugging Rust code in CLion](https://blog.jetbrains.com/clion/2019/10/debugging-rust-code-in-clion/).
+* [My favorite rust function `std::mem::drop`](https://blog.jabid.in/2019/10/11/drop.html).
+* [Vulnerability in sodiumoxide: generichash::Digest::eq always return true](https://www.reddit.com/r/rust/comments/dguqt3/vulnerability_in_sodiumoxide_generichashdigesteq/).
+* [RISC-V OS using Rust: Communications](http://osblog.stephenmarz.com/ch2.html).
+* [Migrating a crate from futures 0.1 to 0.3](https://www.ncameron.org/blog/migrating-a-crate-from-futures-0-1-to-0-3/).
+* [Adventures in motion control: The communications system part 2](http://adventures.michaelfbryan.com/posts/comms-part-2/).
+* [Announcing Rustup 1.20.0](https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html).
+* [New VxWorks release supports Rust](https://www.windriver.com/news/press/pr.html?ID=22444).
+* [AWS’ sponsorship of the Rust Project](https://aws.amazon.com/blogs/opensource/aws-sponsorship-of-the-rust-project/).
+
+Number: 309  Date: 2019-10-22 
+
+* [I made a NES emulator in Rust using generators](https://kyle.space/posts/i-made-a-nes-emulator/).
+* [Where rustc spends its time](https://wiki.alopex.li/WhereRustcSpendsItsTime).
+* [2019 compiler roadmap progress](https://internals.rust-lang.org/t/2019-roadmap-progress/10862/7).
+* [Update on const generics progress](https://github.com/rust-lang/rust/issues/44580#issuecomment-544155666).
+* [Asynchronous destructors](https://boats.gitlab.io/blog/post/poll-drop/).
+* [A tiny, static, full-text search engine using Rust and WebAssembly](https://endler.dev/2019/tinysearch/).
+* [MicroRust: discover the world of microcontrollers through Rust on the BBC micro:bit](https://droogmic.github.io/microrust/).
+* [Dealing with process termination in Linux](https://iximiuz.com/en/posts/dealing-with-processes-termination-in-Linux/).
+* [The embedded WG's operating system tutorials rewrite added support for the Raspberry Pi 4](https://github.com/rust-embedded/rust-raspi3-OS-tutorials/tree/rewrite_for_v2).
+* [Adventures in motion control: simple automation sequences](http://adventures.michaelfbryan.com/posts/simple-automation-sequences/)
+* [Programming Servo: shipping message-ports(via a detour into Spectre)](https://medium.com/programming-servo/programming-servo-shipping-message-ports-via-a-detour-into-spectre-c96683ac0b8).
+* [Rotary encoders in embedded Rust](https://leshow.github.io/post/rotary_encoder_hal/).
+
+Number: 310  Date: 2019-10-29 
+
+* [A call for blogs 2020](https://blog.rust-lang.org/2019/10/29/A-call-for-blogs-2020.html).
+* [Why async fn in traits are hard](https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/).
+* [Spark implemented in Rust with promising results](https://medium.com/@rajasekar3eg/fastspark-a-new-fast-native-implementation-of-spark-from-scratch-368373a29a5c).
+* [Nannou awarded Mozilla grant for foundational audio development in Rust](https://nannou.cc/posts/moss_grant_announce).
+* [Rust and C++ on floating-point intensive code](https://www.reidatcheson.com/hpc/architecture/performance/rust/c++/2019/10/19/measure-cache.html).
+* [docs.rs outage postmortem](https://blog.rust-lang.org/inside-rust/2019/10/24/docsrs-outage-postmortem.html).
+* [Cost of rust-analyzer](https://rust-analyzer.github.io/2019/10/16/finance.html).
+* [Building a widget for Druid (a WIP native Rust GUI toolkit)](https://pauljmiller.com/posts/druid-widget-tutorial.html).
+* [Ferris Fencing - a Rust game built on a RISC-V VM](http://www.ferrisfencing.org/).
+* [Technique for doing specialization on a stable compiler safely](https://github.com/dtolnay/case-studies/blob/master/autoref-specialization/README.md).
+* [A closer look at Ownership in Rust](https://blog.thoughtram.io/ownership-in-rust/).
+* [Programming Servo: the incredibly shrinking timer](https://medium.com/programming-servo/programming-servo-the-incredibly-shrinking-timer-7283ae2a2669).
+* [Making good On momo's compile-time promise](https://llogiq.github.io/2019/10/28/momo-fast.html).
+* [Adventures in motion control: initial motion system](http://adventures.michaelfbryan.com/posts/initial-motion-system/).
+* [Please welcome pnkfelix as compiler team co-lead](https://blog.rust-lang.org/inside-rust/2019/10/24/pnkfelix-compiler-team-co-lead.html).
+
+Number: 311  Date: 2019-11-05 
+
+* [Completing the transition to the new borrow checker](https://blog.rust-lang.org/2019/11/01/nll-hard-errors.html).
+* [Rust support for Windows Runtime in the works by the author of C++ WinRT](https://kennykerr.ca/2019/11/05/rust/).
+* [You probably didn't want `.into_iter().cloned()`](https://www.reddit.com/r/rust/comments/dp3s25/psa_you_probably_didnt_want_into_itercloned/).
+* [Clippy is removing its plugin interface](https://blog.rust-lang.org/inside-rust/2019/11/04/Clippy-removes-plugin-interface.html).
+* [Rust concurrency patterns: condvars and locks](https://medium.com/@polyglot_factotum/rust-concurrency-patterns-condvars-and-locks-e278f18db74f).
+* [How to make your C codebase rusty: rewriting keyboard firmware keymap in Rust](https://about.houqp.me/posts/rusty-c/).
+* [When writing a bump allocator, always bump downwards](https://fitzgeraldnick.com/2019/11/01/always-bump-downwards.html).
+* [Adventures in motion control: initial motion system](http://adventures.michaelfbryan.com/posts/initial-motion-system/).
+* [2019-10-24 compiler team triage meeting](https://blog.rust-lang.org/inside-rust/2019/10/30/compiler-team-meeting.html).
+### #Rust2020
+Find all #Rust2020 posts at [Read Rust](https://readrust.net/rust-2020/).
+
+Number: 312  Date: 2019-11-12 
+
+* 🎈🎉 [Announcing Rust 1.39.0](https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html). 🎉🎈
+* [Async-await on stable Rust](https://blog.rust-lang.org/2019/11/07/Async-await-stable.html).
+* [Announcing async-std 1.0](https://async.rs/blog/announcing-async-std-1-0/).
+* [Futures 0.3 released (with async/await support)](https://github.com/rust-lang-nursery/futures-rs/releases/tag/0.3.0).
+* [Comparing parallel Rust and C++](https://parallel-rust-cpp.github.io/).
+* [Using type-level programming in Rust to make safer hardware abstractions](https://blog.auxon.io/2019/10/25/type-level-registers/).
+* [Demystifying asynchronous Rust](https://github.com/teh-cmc/rust-async/blob/master/README.md).
+* [CSS in librsvg is now in Rust, courtesy of Mozilla Servo](https://people.gnome.org/~federico/blog/css-in-librsvg-is-now-in-rust.html).
+* [How Swift achieved dynamic linking where Rust couldn't](https://gankra.github.io/blah/swift-abi/).
+* [Experimental rewrite of a low-level system component of the Windows codebase](https://msrc-blog.microsoft.com/2019/11/07/using-rust-in-windows/).
+* [iou: Rust bindings for liburing](https://boats.gitlab.io/blog/post/iou/).
+* [Generalizing coroutines in Rust](https://samsartor.com/coroutines-1/).
+* [Notes on type layouts and ABIs in Rust](https://gankra.github.io/blah/rust-layouts-and-abis/).
+* [Putting Rust in the kernel with eBPF](https://blog.redsift.com/labs/putting-rust-in-the-kernel-with-ebpf/).
+* [Adventures in Motion Control: Working With G-Code](http://adventures.michaelfbryan.com/posts/working-with-gcode/).
+* [Search for Rust crates with Meili](https://blog.meilisearch.com/search-rust-crates-meili/).
+### #Rust2020
+Find all #Rust2020 posts at [Read Rust](https://readrust.net/rust-2020/).
+
+Number: 313  Date: 2019-11-19 
+
+* [Stacked borrows: An aliasing model for Rust](https://www.ralfj.de/blog/2019/11/18/stacked-borrows-paper.html).
+* [Implementing ArrayVec using const generics](http://adventures.michaelfbryan.com/posts/const-arrayvec/).
+* [Thoughts on error handling in Rust](https://lukaskalbertodt.github.io/2019/11/14/thoughts-on-error-handling-in-rust.html).
+* [Understanding Serde](https://www.joshmcguigan.com/blog/understanding-serde/).
+* [rust-analyzer: Find usages](https://rust-analyzer.github.io/2019/11/13/find-usages.html).
+* [Global executors](https://boats.gitlab.io/blog/post/global-executors/).
+* [Rust Infrastructure team: Evaluating GitHub Actions](https://blog.rust-lang.org/inside-rust/2019/11/14/evaluating-github-actions.html).
+* [Rust bug minimization patterns](http://blog.pnkfx.org/blog/2019/11/18/rust-bug-minimization-patterns/).
+* [Teaching Rust in IoT with PineTime smart watch](https://medium.com/swlh/sneak-peek-of-pinetime-smart-watch-and-why-its-perfect-for-teaching-iot-81b74161c159).
+### #Rust2020
+Find all #Rust2020 posts at [Read Rust](https://readrust.net/rust-2020/).
+
+Number: 314  Date: 2019-11-26 
+
+* [Tokio roadmap to 1.0](https://tokio.rs/blog/2019-11-tokio-0-2/).
+* [Shipping a compiler every six weeks](https://www.pietroalbini.org/blog/shipping-a-compiler-every-six-weeks/).
+* [`if` and `match` in constants on nightly rust](https://blog.rust-lang.org/inside-rust/2019/11/25/const-if-match.html).
+* [Towards a unified theory of reactive UI](https://raphlinus.github.io/ui/druid/2019/11/22/reactive-ui.html).
+* [Surveying error handling libraries](https://blog.yoshuawuyts.com/error-handling-survey/).
+* [Porting librsvg to Rust: Refactoring the Length type](https://people.gnome.org/~federico/blog/refactoring-the-length-type.html).
+* [Lessons learned by transpiling C to Rust](https://immunant.com/blog/2019/11/rust2020/).
+* [How to panic in Rust](https://www.ralfj.de/blog/2019/11/25/how-to-panic-in-rust.html).
+* [Neat Rust tricks: Passing Rust closures to C](https://blog.seantheprogrammer.com/neat-rust-tricks-passing-rust-closures-to-c).
+* [Moving gnome-shell's styles to Rust](https://people.gnome.org/~federico/blog/moving-gnome-shell-styles-to-rust.html).
+* [Async-awaitifying a Rust CLI App](https://zupzup.org/async-awaitify-rust-cli/).
+* [Building a Rust driver for PineTime’s touch controller](https://medium.com/@ly.lee/building-a-rust-driver-for-pinetimes-touch-controller-cbc1a5d5d3e9).
+* [RustFest Barcelona talk recordings are now available](https://blog.rustfest.eu/this-week-in-rustfest-barcelona-videos).
+* [Cryptowatch is sponsoring development of Rust GUI library iced](https://blog.cryptowat.ch/2019/11/25/sponsoring-rust-gui-library-iced/).
+### #Rust2020
+Find all #Rust2020 posts at [Read Rust](https://readrust.net/rust-2020/).
+
+Number: 315  Date: 2019-12-03 
+
+* [Constant propagation is now on by default in nightly](https://blog.rust-lang.org/inside-rust/2019/12/02/const-prop-on-by-default.html).
+* [Redox OS: Real hardware breakthroughs, and focusing on rustc](https://www.redox-os.org/news/focusing-on-rustc/).
+* [Taking ML to production with Rust: a 25x speedup](https://www.lpalmieri.com/posts/2019-12-01-taking-ml-to-production-with-rust-a-25x-speedup/).
+* [How to RiiR](http://adventures.michaelfbryan.com/posts/how-to-riir/index.html).
+* [Launching the 2019 State of Rust Survey](https://blog.rust-lang.org/2019/12/03/survey-launch.html).
+* [Announcing http v0.2](https://seanmonstar.com/post/189439210962/http-v02).
+* [Implementing pid1 with Rust and async/await](https://tech.fpcomplete.com/rust/pid1).
+* [Tide: the present and future](https://blog.yoshuawuyts.com/tide/).
+* [Let's make a simple authentication server in Rust with Warp](https://blog.joco.dev/posts/warp_auth_server_tutorial).
+* [Down and dirty with Future - Rust crash course lesson 8](https://www.snoyman.com/blog/2019/12/rust-crash-course-08-down-dirty-future).
+* [The Embedded WG newsletter 21](https://rust-embedded.github.io/blog/newsletter-21/).
+### #Rust2020
+Find all #Rust2020 posts at [Read Rust](https://readrust.net/rust-2020/).
+
+Number: 316  Date: 2019-12-10 
+
+* [How to speed up the Rust compiler one last time in 2019](https://blog.mozilla.org/nnethercote/2019/12/11/how-to-speed-up-the-rust-compiler-one-last-time-in-2019/).
+* [Formatting is unreasonably expensive for embedded Rust](https://jamesmunns.com/blog/fmt-unreasonably-expensive/).
+* [Some parts 1Password X Manager are rewritten in Rust](https://blog.1password.com/1passwordx-december-2019-release/).
+* [Announcing hyper v0.13 with full async/await support](https://seanmonstar.com/post/189594157852/hyper-v013).
+* [Blocking inside async code](https://stjepang.github.io/2019/12/04/blocking-inside-async-code.html).
+* [Announcing the docs.rs team](https://blog.rust-lang.org/inside-rust/2019/12/09/announcing-the-docsrs-team.html).
+* [Writing the slowest quicksort](https://chasewilson.dev/blog/slowest-quicksort/).
+* [Soundness bugs in Rust libraries: can't live with 'em, can't live without 'em](https://docs.rs/dtolnay/0.0.7/dtolnay/macro._03__soundness_bugs.html).
+* [Tiny Windows executable in Rust in 3.5 kbytes](https://www.codeslow.com/2019/12/tiny-windows-executable-in-rust.html).
+* [Inside Rust at Embark](https://medium.com/embarkstudios/inside-rust-at-embark-b82c06d1d9f4).
+* [Tokio 0.2 - Rust crash course](https://www.snoyman.com/blog/2019/12/rust-crash-course-09-tokio-0-2).
+* [Generalized autoref-based specialization](https://lukaskalbertodt.github.io/2019/12/05/generalized-autoref-based-specialization.html).
+* [A rusty radio: Si4703 FM radio receiver driver](https://blog.eldruin.com/si4703-fm-radio-receiver-driver-in-rust/).
+### #Rust2020
+Find all #Rust2020 posts at [Read Rust](https://readrust.net/rust-2020/).
+
+Number: 317  Date: 2019-12-17 
+
+* [Bisecting Rust compiler regressions with cargo-bisect-rustc](https://blog.rust-lang.org/inside-rust/2019/12/18/bisecting-rust-compiler.html).
+* [Stop worrying about blocking: the new async-std runtime, inspired by Go](https://async.rs/blog/stop-worrying-about-blocking-the-new-async-std-runtime/).
+* [From zero to main(): Bare metal Rust](https://interrupt.memfault.com/blog/zero-to-main-rust-1).
+* [WASM as a platform for abstraction](http://adventures.michaelfbryan.com/posts/wasm-as-a-platform-for-abstraction/).
+* [New gtk-rs release: Simplification and more of everything](https://gtk-rs.org/blog/2019/12/15/new-release.html).
+* [Announcing Mio 0.7-alpha.1](https://tokio.rs/blog/2019-12-mio-v0.7-alpha.1/).
+* [Introduction to Rendology: A Glium-based rendering pipeline](https://leod.github.io/rust/gamedev/rendology/2019/12/13/introduction-to-rendology.html).
+* [The common Rust traits](https://stevedonovan.github.io/rustifications/2018/09/08/common-rust-traits.html).
+* [Solving the Burger problem with Rust](https://rust-malaysia.github.io/code/2019/12/15/the-burger-problem.html).
+* [Porting druid Rust widgets to PineTime smart watch](https://medium.com/@ly.lee/porting-druid-rust-widgets-to-pinetime-smart-watch-7e1d5a5d977a).
+* [Relm tutorial](https://relm.antoyo.xyz/documentation/tutorial/).
+* [Why does rust seem to inspire people](https://www.reddit.com/r/rust/comments/eaay3c/why_does_rust_seem_to_inspire_people/)?
+
+Number: 318  Date: 2019-12-24 
+
+* 🎈🎉 [Announcing Rust 1.40.0](https://blog.rust-lang.org/2019/12/19/Rust-1.40.0.html). 🎉🎈
+* [Learn Rust the dangerous way](http://cliffle.com/p/dangerust/).
+* [Announcing Tokio-Compat](https://tokio.rs/blog/2019-12-compat/).
+* [Async exceptions in Haskell, and Rust](https://tech.fpcomplete.com/blog/async-exceptions-haskell-rust).
+* [actix-web v2.0 released](https://github.com/actix/actix-web/releases/tag/web-v2.0.0).
+* [Announcing the official MongoDB Rust driver](https://www.mongodb.com/blog/post/announcing-the-official-mongodb-rust-driver).
+* [JetBrains - Rustlings course adaptation](https://blog.jetbrains.com/blog/2019/12/19/rustlings-course-adaptation/).
+* [Writing BPF code in Rust](https://blog.redsift.com/labs/writing-bpf-code-in-rust/).
+* [Testing for no_std compatibility in Rust crates](https://blog.dbrgn.ch/2019/12/24/testing-for-no-std-compatibility/).
+* [Source code linking: Merging C headers into Rust modules](https://immunant.com/blog/2019/12/header_merging/).
+* [Serverless Rust using WASM and Cloudflare](https://tech.fpcomplete.com/blog/serverless-rust-wasm-cloudflare).
+* [Porting a JavaScript app to WebAssembly with Rust (part 1)](https://slowtec.de/posts/2019-12-20-porting-javascript-to-rust-part-1.html).
+* [Down the stack: Compiled Rust part 1](https://blog.ryanlevick.com/down-the-stack-part-1/).
+* [Formatting the compiler tree](https://blog.rust-lang.org/inside-rust/2019/12/23/formatting-the-compiler.html).
+* [Streams concurrency](https://blog.yoshuawuyts.com/streams-concurrency/).
+* [Writing a seqlock in Rust](https://pitdicker.github.io/Writing-a-seqlock-in-Rust/).
+* [Platform agnostic driver for Vishay's VEML6030 and VEML7700 ambient light sensors](https://blog.eldruin.com/veml6030-ambient-light-sensor-driver-in-rust/).
+* [PCA9685 16-channel PWM LED/servo motor controller driver](https://blog.eldruin.com/pca9685-pwm-led-servo-controller-driver-in-rust/).
+* [Congrats to compiler team members matthewjasper and wesleywiser](https://blog.rust-lang.org/inside-rust/2019/12/19/jasper-and-wiser-full-members-of-compiler-team.html).
+
+Number: 319  Date: 2019-12-31 
+
+* [Rewriting m4vgalib in Rust](http://cliffle.com/blog/m4vga-in-rust/).
+* [A thought experiment: Using the ECS pattern outside of game engines](http://adventures.michaelfbryan.com/posts/ecs-outside-of-games/).
+* [Spinlocks considered harmful](https://matklad.github.io//2020/01/02/spinlocks-considered-harmful.html).
+* [The state Of ggez, 2020](https://wiki.alopex.li/TheStateOfGGEZ2020).
+* [Interior mutability patterns](https://pitdicker.github.io/Interior-mutability-patterns/).
+* [Should Clippy care from whence they came](https://llogiq.github.io/2020/01/01/clippy.html)?
+* [Writing AWS Lambda functions in Rust](https://silentbyte.com/writing-aws-lambda-functions-in-rust).
+* [Rust lifetimes and iterators](https://blog.katona.me/2019/12/29/Rust-Lifetimes-and-Iterators/).
+* [Rocket and multipart forms](https://blog.krruzic.xyz/rocket-multipart/).
+* [Lyon 0.15.0 - a new tessellator](https://nical.github.io/posts/new-tessellator.html).
+* [The embedded WG's Raspberry Pi OS dev tutorials: Tutorial 13 - Kernel unit, integration, and console tests using QEMU](https://github.com/rust-embedded/rust-raspi3-OS-tutorials/tree/master/13_integrated_testing).
+* [Optimising PineTime’s display driver with Rust and Mynewt](https://medium.com/@ly.lee/optimising-pinetimes-display-driver-with-rust-and-mynewt-3ba269ea2f5c).
+* [The embedded WG newsletter 22](https://rust-embedded.github.io/blog/newsletter-22/).
+* [rust-analyzer changelog 5](https://rust-analyzer.github.io/thisweek/2019/12/30/changelog-5.html).
+* [Rust in blockchain 7 – December 2019](https://rustinblockchain.org/2020/01/02/rust-in-blockchain-7-december-2019/).
+
+Number: 320  Date: 2020-01-07 
+
+* [Translating Quake 3 into Rust](https://immunant.com/blog/2020/01/quake3/).
+* [Reducing support for 32-bit Apple targets](https://blog.rust-lang.org/2020/01/03/reducing-support-for-32-bit-apple-targets.html).
+* [Learn Rust the dangerous way: Let the compiler do the work](http://cliffle.com/p/dangerust/6/).
+* [Mutexes are faster than spinlocks](https://matklad.github.io/2020/01/04/mutexes-are-faster-than-spinlocks.html).
+* [Writing an OS in Rust: Updates in December 2019](https://os.phil-opp.com/status-update/2020-01-07/).
+* [Update on const generics progress](https://github.com/rust-lang/rust/issues/44580#issuecomment-570191702).
+* [Elastic releases official Elasticsearch Rust client](https://github.com/elastic/elasticsearch-rs).
+* [Backpressure in async ecosystems](https://lucumr.pocoo.org/2020/1/1/async-pressure/).
+* [Explaining atomics in Rust](https://cfsamsonbooks.gitbook.io/explaining-atomics-in-rust/).
+* [Announcing ÄroRust - an unofficial Rust + Aerospace Working Group](https://github.com/AeroRust).
+* [Videos from Rust Belt Rust 2019 are now available](https://www.youtube.com/playlist?list=PLgC1L0fKd7UkVwjVlOySfMnn80Qs5TOLb).
+* [A primer on Rust’s Result type](https://medium.com/@JoeKreydt/a-primer-on-rusts-result-type-66363cf18e6a).
+
+Number: 321  Date: 2020-01-14 
+
+* [Rust code in Unreal Engine](https://ejmahler.github.io/rust_in_unreal/).
+* [Introduction - Roguelike tutorial](http://bfnightly.bracketproductions.com/rustbook/chapter_0.html).
+* [Towards a Rust foundation](https://smallcultfollowing.com/babysteps/blog/2020/01/09/towards-a-rust-foundation/).
+* [Way Cooler postmortem](http://way-cooler.org/blog/2020/01/09/way-cooler-post-mortem.html).
+* [Why Rust? I have a GC](https://llogiq.github.io/2020/01/10/rustvsgc.html)!
+* [rust-analyzer changelog 7](https://rust-analyzer.github.io/thisweek/2020/01/13/changelog-7.html).
+* [This month in Rust gamedev 5 - December 2019](https://rust-gamedev.github.io/posts/newsletter-005/).
+* [RDBC is moving to Tokio](https://andygrove.io/2020/01/rust-database-connectivity-rdbc/).
+* [Synthesizing loop-free programs with Rust and Z3](https://fitzgeraldnick.com/2020/01/13/synthesizing-loop-free-programs.html).
+* [Containerized builds for Rust on the ESP32](https://dev.to/mtnmts/containerized-builds-for-rust-on-the-esp32-e8m).
+* [Implementing a cooperative scheduler in a Rust kernel](https://ryan-jacobs1.github.io/2020/01/06/scheduler.html).
+
+Number: 322  Date: 2020-01-21 
+
+* [Smoke-testing Rust HTTP clients](https://medium.com/@shnatsel/smoke-testing-rust-http-clients-b8f2ee5db4e6).
+* [A sad day for Rust](https://words.steveklabnik.com/a-sad-day-for-rust).
+* [What is Rust and why is it so popular](https://stackoverflow.blog/2020/01/20/what-is-rust-and-why-is-it-so-popular/) - from official StackOverflow blog.
+* [Writing an OS in Rust: Allocator designs](https://os.phil-opp.com/allocator-designs/).
+* [How refactoring a macro reduced my Rust project compilation time from 4 hours to 40 seconds](https://users.rust-lang.org/t/5-hours-to-compile-macro-what-can-i-do/36508).
+* [Why the stabilization of advanced slice patterns is a big deal to me](https://thomashartmann.dev/blog/feature(slice_patterns)/).
+* [How to write fast Rust code](http://likebike.com/posts/How_To_Write_Fast_Rust_Code.html).
+* [Exposing C and Rust APIs: some thoughts from librsvg](https://people.gnome.org/~federico/blog/exposing-c-and-rust-apis.html).
+* [Rust on the ESP32 - SVD's, PAC's and USB flashing](https://mabez.dev/blog/posts/esp32-rust-svd-pac/).
+* [Epoll, Kqueue and IOCP explained with Rust](https://cfsamsonbooks.gitbook.io/epoll-kqueue-iocp-explained/).
+* [Programming Servo: three years, 100 commits](https://medium.com/programming-servo/programming-servo-three-years-100-commits-a3cbfb06ff23).
+* [Project Verona: Microsoft's Rust inspired research language has been released](https://github.com/microsoft/verona).
+
+Number: 323  Date: 2020-01-28 
+
+* [cargo-audit v0.11: Introducing the `fix` feature, yanked crate detection, and more](https://blog.rust-lang.org/inside-rust/2020/01/23/Introducing-cargo-audit-fix-and-more.html).
+* [Bitfields forever: Why we need a C-compatible Rust crate](https://immunant.com/blog/2020/01/bitfields/).
+* [Units of measure in Rust with refinement types](https://yoric.github.io/post/uom.rs/).
+* [std.rs: go directly to stable rust docs](https://std.rs/).
+* [A stack-less Rust coroutine library under 100 LoC](https://blog.aloni.org/posts/a-stack-less-rust-coroutine-100-loc/).
+* [How Zebra used Tower to replace Zcash's legacy Bitcoin C++ networking code with modern, async Rust](https://www.zfnd.org/blog/a-new-network-stack-for-zcash/).
+* [Build your own `block_on()`](https://stjepang.github.io/2020/01/25/build-your-own-block-on.html).
+* [Packaging a Rust project for Debian](https://blog.hackeriet.no/packaging-a-rust-project-for-debian/).
+* [Byte ordered streams](https://yoshuawuyts-blog.netlify.com/byte-ordered-stream-parsing/).
+* [Tide channels](https://blog.yoshuawuyts.com/tide-channels/).
+* [Lessons learnt updating a library to std::future](https://cetra3.github.io/blog/mpart-async-0-3-0/).
+* [Returning trait objects](https://bryce.fisher-fleig.org/blog/returning-trait-objects/).
+* [Debug Rust+Mynewt firmware for PineTime on Raspberry Pi](https://medium.com/@ly.lee/debug-rust-mynewt-firmware-for-pinetime-on-raspberry-pi-4b9ac2d093a9).
+* [rust-analyzer changelog 9](https://rust-analyzer.github.io/thisweek/2020/01/27/changelog-9.html).
+
+Number: 324  Date: 2020-02-04 
+
+* 🎈🎉 [Announcing Rust 1.41.0](https://blog.rust-lang.org/2020/01/30/Rust-1.41.0.html). 🎉🎈
+* [Why Discord is switching from Go to Rust](https://blog.discordapp.com/why-discord-is-switching-from-go-to-rust-a190bbca2b1f).
+* [Writing an OS in Rust: Updates in January 2020](https://os.phil-opp.com/status-update/2020-02-01/).
+* [Measuring space-time behaviours of piano keys with Rust](https://jitter.company/blog/2020/01/28/measuring-space-time-behaviours-of-piano-keys-with-rust/).
+* [Build your own executor](https://stjepang.github.io/2020/01/31/build-your-own-executor.html).
+* [Cross compiling Rust on Linux for the Raspberry Pi](https://chacin.dev/blog/cross-compiling-rust-for-the-raspberry-pi/).
+* [The 2020 Rust event lineup](https://blog.rust-lang.org/2020/01/31/conf-lineup.html).
+* [Writing AWS Lambda functions with Bastion](https://blog.bastion.rs/2020/02/01/writing-aws-lambda-functions-with-bastion.html).
+* [rust-search-extension: Search std docs, crates, error codes, and attributes in browser's address bar](https://www.reddit.com/r/rust/comments/eymfxu/announcing_rustsearchextension_v07_search_std/).
+* [The Embedded WG newsletter 23](https://rust-embedded.github.io/blog/newsletter-23/).
+* [Rust Analyzer changelog 10](https://rust-analyzer.github.io/thisweek/2020/02/03/changelog-10.html).
+* [IntelliJ Rust changelog 115](https://intellij-rust.github.io/2020/02/04/changelog-115.html).
+* [Rust in Blockchain newsletter 8: Looking forward to 2020](https://rustinblockchain.org/2020/02/05/rib-newsletter-8-looking-forward-to-2020/).
+* [Announcing async-std v1.5.0](https://github.com/async-rs/async-std/releases/tag/v1.5.0).
+* [Announcing Tide 0.6.0](https://github.com/http-rs/tide/releases/tag/v0.6.0).
+
+Number: 325  Date: 2020-02-11 
+
+* [Alex Crichton: Scaling back my involvement in Rust](https://internals.rust-lang.org/t/scaling-back-my-involvement-in-rust/11754).
+* [Bringing async/await to embedded Rust](https://ferrous-systems.com/blog/embedded-async-await/).
+* [Announcing the Cleanup Crew ICE-breaker group](https://blog.rust-lang.org/inside-rust/2020/02/06/Cleanup-Crew-ICE-breakers.html).
+* [Results from Rust game development ecosystem survey](https://rust-gamedev.github.io/posts/survey-01/).
+* [The `std::future::Future` of Rusoto](https://linuxwit.ch/blog/2020/02/the-future-of-rusoto/).
+* [Debugging Rust in VSCode (in 2020)](https://jason-williams.co.uk/debugging-rust-in-vscode).
+* [Rust and GTK from a React perspective](https://savanni.luminescent-dreams.com/2020/01/15/rust-react-gtk/).
+* [A primer to Rust Async](https://omarabid.com/async-rust).
+* [Solving sparse matrix systems in Rust](https://medium.com/swlh/solving-sparse-matrix-systems-in-rust-5e978ed07bc3).
+* [I made a thing: Markedit](http://adventures.michaelfbryan.com/posts/markedit/).
+* [Creating interactive applications](http://adventures.michaelfbryan.com/posts/implementing-interactive-applications/).
+* [Async interview 6: Eliza Weisman](https://smallcultfollowing.com/babysteps/blog/2020/02/11/async-interview-6-eliza-weisman/).
+* [rust-analyzer changelog 11](https://rust-analyzer.github.io/thisweek/2020/02/10/changelog-11.html).
+
+Number: 326  Date: 2020-02-18 
+
+* [Sealed Rust update: The plan for safety critical Rust](https://ferrous-systems.com/blog/sealed-rust-the-plan/).
+* [Why is Rust the most loved programming language](https://matklad.github.io/2020/02/14/why-rust-is-loved.html)?
+* [Rust ghost, signing off](https://quietmisdreavus.net/self/2020/02/17/rust-ghost-signing-off/).
+* [I audited 3 different implementation of async RwLock](https://www.reddit.com/r/rust/comments/f4zldz/i_audited_3_different_implementation_of_async/).
+* [`deny(warnings)` is actively harmful](https://www.reddit.com/r/rust/comments/f5xpib/psa_denywarnings_is_actively_harmful/).
+* [Rust for Java devs](https://leshow.github.io/post/rust_for_java_devs/).
+* [Some nuances of undefined behavior in Rust](https://typr124.github.io/UB1).
+* [A pragmatic approach to global state](http://adventures.michaelfbryan.com/posts/pragmatic-global-state/)
+* [Graphs in Rust: Introducing GraphCore](https://depth-first.com/articles/2020/02/17/graphs-in-rust-introducting-graphcore/).
+* [faux - an inside look](https://nrxus.github.io/faux/blog/how-it-works.html)
+* [rust-analyzer changelog 12](https://rust-analyzer.github.io/thisweek/2020/02/17/changelog-12.html).
+* [IntelliJ Rust changelog 116](https://intellij-rust.github.io/2020/02/18/changelog-116.html).
+* [This month in Rust GameDev 6 - January 2020](https://rust-gamedev.github.io/posts/newsletter-006/).
+
+Number: 327  Date: 2020-02-25 
+
+* [Working with strings in Rust](https://fasterthanli.me/blog/2020/working-with-strings-in-rust/).
+* [Rust/WinRT coming soon](https://kennykerr.ca/2020/02/22/rust-winrt-coming-soon/).
+* [Intro to rustc's self profiler](https://blog.rust-lang.org/inside-rust/2020/02/25/intro-rustc-self-profile.html).
+* [crates.io incident report for 2020-02-20](https://blog.rust-lang.org/inside-rust/2020/02/26/crates-io-incident-report.html).
+* [Filtering duplicates on the command line: 30x faster than sort|uniq](https://medium.com/adobetech/filtering-duplicates-on-the-command-line-30x-faster-than-sort-uniq-96ca5f7b4277).
+* [Making our own executable packer](https://fasterthanli.me/blog/2020/whats-in-a-linux-executable/).
+* [Line simplification with Ramer–Douglas–Peucker](http://adventures.michaelfbryan.com/posts/line-simplification/).
+* [Async HTTP](https://blog.yoshuawuyts.com/async-http/).
+* [Further thoughts on async/await](https://medium.com/@polyglot_factotum/further-thoughts-on-async-await-7767f924cb7e).
+* [Triage at scale for the Rust team](https://docs.rs/dtolnay/0.0.8/dtolnay/macro._04__triage_scale.html).
+* [Presenting Dali, an image processor service](https://tech.olx.com/presenting-dali-an-image-processor-service-514e6be00de8).
+* [Anouncing async_executors, a building block for executor agnostic libraries](https://blog.wnut.pw/2020/02/25/anouncing-async_executors-a-building-block-for-executor-agnostic-libraries/).
+* [Building TodoMVC With vgtk](https://bodil.lol/vgtk/).
+* [Host Rust+Wasm projects on github pages or other](https://github.com/sn99/wasm-template-rust).
+* [Programming Servo: implementing BroadcastChannel](https://medium.com/programming-servo/programming-servo-implementing-broadcastchannel-94516289ecd4).
+* [Fuchsia programming language policy](https://fuchsia.googlesource.com/fuchsia/+/refs/heads/master/docs/project/policy/programming_languages.md).
+* [rust-analyzer changelog 113](https://rust-analyzer.github.io/thisweek/2020/02/24/changelog-13.html).
+
+Number: 328  Date: 2020-03-03 
+
+* [Announcing Rust 1.41.1](https://blog.rust-lang.org/2020/02/27/Rust-1.41.1.html).
+* [A half-hour to learn Rust](https://fasterthanli.me/blog/2020/a-half-hour-to-learn-rust/).
+* [Recent and future pattern matching improvements](https://blog.rust-lang.org/inside-rust/2020/03/04/recent-future-pattern-matching-improvements.html).
+* [Cheap tricks for high-performance Rust](https://deterministic.space/high-performance-rust.html).
+* [Understanding String and &str in Rust](https://blog.thoughtram.io/string-vs-str-in-rust/).
+* [caniuse.rs - Rust feature search](https://caniuse.rs/).
+* [Async/await on embedded Rust](https://ferrous-systems.com/blog/async-on-embedded/).
+* [Audit of the RustCrypto `aes-gcm` and `chacha20poly1305` crates by NCC group](https://research.nccgroup.com/2020/02/26/public-report-rustcrypto-aes-gcm-and-chacha20poly1305-implementation-review/).
+* [FFI patterns #1 - Complex Rust data structures exposed seamlessly to C++](https://crisal.io/words/2020/02/28/C++-rust-ffi-patterns-1-complex-data-structures.html).
+* [Multidimensional arrays and operations with NDArray](https://shahinrostami.com/posts/programming/rust-notebooks/multidimensional-arrays-and-operations-with-ndarray/).
+* [A look into ways to implement and share data with interrupt handlers in Rust](https://therealprof.github.io/blog/interrupt-comparison/).
+* [Porting a JavaScript App to WebAssembly with Rust (Part 3)](https://www.slowtec.de/posts/2020-02-28-porting-javascript-to-rust-part-3.html).
+* [Pietro Albini has joined the core team](https://blog.rust-lang.org/inside-rust/2020/02/27/pietro-joins-core-team.html).
+* [Announcing the first FFI-unwind project design meeting](https://blog.rust-lang.org/inside-rust/2020/02/27/ffi-unwind-design-meeting.html).
+* [Writing an OS in Rust: Updates in February 2020](https://os.phil-opp.com/status-update/2020-03-02/).
+* [rust-analyzer Changelog 14](https://rust-analyzer.github.io/thisweek/2020/03/02/changelog-14.html).
+* [IntelliJ Rust Changelog 117](https://intellij-rust.github.io/2020/03/02/changelog-117.html).
+* [This month in rustsim 9](https://www.rustsim.org/blog/2020/03/01/this-month-in-rustsim/).
+* [Rust in Blockchain newsletter 9: The month of working from home](https://rustinblockchain.org/2020/03/04/rib-newsletter-9-the-month-of-working-from-home/).
+* [Tokio v0.2.12, includes `Notify`, an async/await synchronization primitive, and `StreamMap` for dynamic merging of streams](https://github.com/tokio-rs/tokio/releases/tag/tokio-0.2.12).
+
+Number: 329  Date: 2020-03-10 
+
+* [An alternative to the builder pattern, init struct pattern](https://xaeroxe.github.io/init-struct-pattern/).
+* [Bottlerocket, a new Linux-based OS, uses Rust for almost all new components](https://aws.amazon.com/blogs/aws/bottlerocket-open-source-os-for-container-hosting/).
+* [Parsing Library in Rust pt. 1](https://blog.frondeus.pl/parser-1/).
+* [Yes, I am still learning Rust](https://llogiq.github.io/2020/03/07/learning.html).
+* [I have just made my first open source contribution to rust-analyzer](https://avishay.dev/2020/03/04/oss-contribution/).
+* [Nannou update - WebGPU, capturing frames and more](https://nannou.cc/posts/nannou_v0.13).
+* [A C# programmer examines Rust - Part 1](https://treit.github.io/programming,/rust,/c%23/2020/03/06/StartingRust.html).
+* [My exploration of Rust and .NET](https://ericsink.com/entries/dotnet_rust.html).
+* [cfg(doctest) is stable and you should use it](https://blog.guillaume-gomez.fr/articles/2020-03-07+cfg%28doctest%29+is+stable+and+you+should+use+it).
+* [ExpressJS vs Actix-Web: performance and running cost comparison](https://medium.com/@maxsparr0w/performance-of-node-js-compared-to-actix-web-37f20810fb1a).
+* [rust-analyzer changelog 15](https://rust-analyzer.github.io/thisweek/2020/03/09/changelog-15.html).
+* [This month in Rust gamedev 7 - February 2020](https://rust-gamedev.github.io/posts/newsletter-007/).
+* [The 2020 RustConf CFP is Now Open](https://blog.rust-lang.org/2020/03/10/rustconf-cfp.html).
+
+Number: 330  Date: 2020-03-17 
+
+* 🎈🎉 [Announcing Rust 1.42.0](https://blog.rust-lang.org/2020/03/12/Rust-1.42.html). 🎉🎈
+* [ripgrep 12 is released](https://github.com/BurntSushi/ripgrep/releases/tag/12.0.0).
+* [Rewriting the heart of our sync engine at Dropbox](https://dropbox.tech/infrastructure/rewriting-the-heart-of-our-sync-engine).
+* [docs.rs now allows you to choose your build targets](https://blog.rust-lang.org/2020/03/15/docs-rs-opt-into-fewer-targets.html).
+* [Redox OS - pkgar introduction](https://www.redox-os.org/news/pkgar-introduction/).
+* [Reducing the size of `Option<T>` by adding members to `T`](https://www.reddit.com/r/rust/comments/fimbo3/reducing_the_size_of_optiont_by_adding_members_to/)?
+* [Out of the box dynamic dispatch](https://llogiq.github.io/2020/03/14/ootb.html).
+* [parallel-stream](https://blog.yoshuawuyts.com/parallel-stream/).
+* [Optimizations that aren't, or are they](https://oribenshir.github.io/afternoon_rusting/blog/copy-on-write)?
+* [Rust All Hands retrospective](https://blog.rust-lang.org/inside-rust/2020/03/18/all-hands-retrospective.html).
+* [Guide on how to write documentation for a Rust crate](https://blog.guillaume-gomez.fr/articles/2020-03-12+Guide+on+how+to+write+documentation+for+a+Rust+crate).
+* [A C# programmer examines Rust - Part 2](https://treit.github.io/rust,/c%23,/programming/2020/03/15/StartingRustPart2.html).
+* [Traits, dynamic dispatch and upcasting](https://articles.bchlr.de/traits-dynamic-dispatch-upcasting).
+* [References in Rust](https://blog.thoughtram.io/references-in-rust/).
+* [Parsing library in Rust pt. 2 - test utilities](https://blog.frondeus.pl/parser-2/).
+* [Loading datasets from CSV into NDArray](https://shahinrostami.com/posts/programming/rust-notebooks/loading-datasets-from-csv-into-ndarray/).
+* [Announcing Rust Search Extension v0.8](https://www.reddit.com/r/rust/comments/fg5wo1/announcing_rustsearchextension_v08_the_ultimate/).
+* [Async interview 7: withoutboats](https://smallcultfollowing.com/babysteps/blog/2020/03/10/async-interview-7-withoutboats/).
+* [rust-analyzer changelog 16](https://rust-analyzer.github.io/thisweek/2020/03/16/changelog-16.html).
+* [IntelliJ Rust changelog 118](https://intellij-rust.github.io/2020/03/16/changelog-118.html).
+* [Postponing RustFest Netherlands](https://blog.rustfest.eu/postponing-rustfest-nl).
+* [Rust Latam 2020 (Mexico) is cancelled](https://rustlatam.org/index.html#cancel).
+
+Number: 331  Date: 2020-03-24 
+
+* [Plans for the regex crate](https://github.com/rust-lang/regex/issues/656).
+* [Tokio's new internal semaphore based on intrusive lists](https://github.com/tokio-rs/tokio/commit/acf8a7da7a64bf08d578db9a9836a8e061765314).
+* [Rust async and the terrible, horrible, no good, very bad day](https://medium.com/@KevinHoffman/rust-async-and-the-terrible-horrible-no-good-very-bad-day-348ebc836274).
+* [C++20 & Rust on static vs dynamic generics](https://www.youtube.com/watch?v=olM7o_oYML0).
+* [Fast and simple Rust interner](https://matklad.github.io/2020/03/22/fast-simple-rust-interner.html).
+* [Secure Rust guidelines](https://anssi-fr.github.io/rust-guide/).
+* [How I structure my apps (in Rust and other languages)](https://dpc.pw/how-i-structure-my-apps-in-rust-and-other-languages).
+* [Cheatsheet: Option (in Rust) vs Maybe (in Haskell)](https://notes.iveselov.info/programming/cheatsheet-rust-option-vs-haskell-maybe).
+* [Two years with Rust](http://brooker.co.za/blog/2020/03/22/rust.html).
+* [Reducing memory consumption in librsvg, part 3: slack space in Bézier paths](https://people.gnome.org/~federico/blog/reducing-memory-consumption-in-librsvg-3.html).
+* [Inviting God's wrath with cursed Rust](http://troubles.md/abusing-rustc/).
+* [Let’s write a Web Assembly interpreter (part 1)](https://medium.com/@richardanaya/lets-write-a-web-assembly-interpreter-part-1-287298201d75).
+* [Descriptive statistics with NDArray](https://shahinrostami.com/posts/programming/rust-notebooks/descriptive-statistics-with-ndarray/).
+* [rust-analyzer changelog #17](https://rust-analyzer.github.io/thisweek/2020/03/23/changelog-17.html).
+* [Announcing Tokei 11: Now over 40–60% faster](https://github.com/XAMPPRocky/tokei/releases/tag/v11.0.0).
+* [Learn Rust building a toy JIRA clone](https://github.com/LukeMathWalker/build-your-own-jira-with-rust).
+* [The original concept for the Rust logo](https://twitter.com/mart3ll/status/1240705442839277569).
+
+Number: 332  Date: 2020-03-31 
+
+* [Writing an OS in Rust: async/await](https://os.phil-opp.com/async-await/).
+* [rustc-dev-guide overview](https://blog.rust-lang.org/inside-rust/2020/03/26/rustc-dev-guide-overview.html).
+* [Tokio: Reducing tail latencies with automatic cooperative task yielding](https://tokio.rs/blog/2020-04-preemption/).
+* [Introducing R2, a router in Rust](https://r2.rs/blog/).
+* [Goodbye, docs team](https://blog.rust-lang.org/inside-rust/2020/03/27/goodbye-docs-team.html).
+* [Traits working group 2020 sprint 1 summary](https://blog.rust-lang.org/inside-rust/2020/03/28/traits-sprint-1.html).
+* [Specs and Legion, two very different approaches to ECS](https://csherratt.github.io/blog/posts/specs-and-legion/).
+* [Reducing memory consumption in librsvg, part 4: compact representation for Bézier paths](https://people.gnome.org/~federico/blog/reducing-memory-consumption-in-librsvg-4.html).
+* [State machines in Rust](https://blog.yoshuawuyts.com/state-machines/).
+* [Macros vs rename](https://rust-analyzer.github.io/blog/2020/03/30/macros-vs-rename.html).
+* [More advanced aspects of pattern matching in Rust](https://notes.iveselov.info/programming/refs-and-pattern-matching-in-rust).
+* [What constitutes a vulnerability](https://boats.gitlab.io/blog/post/vulnerabilities/)?
+* [On generics and associated types](https://thomashartmann.dev/blog/on-generics-and-associated-types/).
+* [rust-analyzer changelog 18](https://rust-analyzer.github.io/thisweek/2020/03/30/changelog-18.html).
+* [IntelliJ Rust changelog 119](https://intellij-rust.github.io/2020/03/30/changelog-119.html).
+* [Rust in blockchain 10](https://rustinblockchain.org/newsletters/2020-04-01-keep-calm-and-hack-more/).
+
+Number: 333  Date: 2020-04-07 
+
+* [Why I'm building a new async runtime](https://stjepang.github.io/2020/04/03/why-im-building-a-new-async-runtime.html).
+* [Futures explained in 200 lines of Rust](https://cfsamson.github.io/books-futures-explained/).
+* [Sled: Error handling in a correctness-critical Rust project](http://sled.rs/errors).
+* [Most commonly ignored lints](https://github.com/rust-lang/rust-clippy/issues/5418).
+* [A brief apology of Ok-Wrapping](https://boats.gitlab.io/blog/post/why-ok-wrapping/).
+* [From failure to Fehler](https://boats.gitlab.io/blog/post/failure-to-fehler/).
+* [The embedded WG's Raspberry Pi OS dev tutorials: Tutorial 14 - exceptions part 2: peripheral IRQs](https://github.com/rust-embedded/rust-raspberrypi-OS-tutorials/tree/master/14_exceptions_part2_peripheral_IRQs).
+* [Contributing to Rust: Nine patches](https://blog.yoshuawuyts.com/nine-patches/).
+* [Inside Rust: Update on the GitHub Actions evaluation](https://blog.rust-lang.org/inside-rust/2020/04/07/update-on-the-github-actions-evaluation.html).
+* [Programming Servo: Workers at your service](https://medium.com/programming-servo/programming-servo-workers-at-your-service-db71e5943511).
+* [Iced, a cross-platform GUI library: New release featuring custom styling, event subscriptions, additional widgets, new examples, and more](https://github.com/hecrj/iced/pull/253).
+* [rust-analyzer changelog 19](https://rust-analyzer.github.io/thisweek/2020/04/06/changelog-19.html).
+* [This month in rustsim 10 - March 2020](https://www.rustsim.org/blog/2020/04/01/this-month-in-rustsim/).
+* [This month in Rust GameDev 8 - March 2020](https://rust-gamedev.github.io/posts/newsletter-008/).
+
+Number: 334  Date: 2020-04-14 
+
+* [How often does Rust change](https://words.steveklabnik.com/how-often-does-rust-change)?
+* [The differences between Ok-wrapping, try blocks, and function level try](https://yaah.dev/try-blocks).
+* [Mental models around Ok-wrapping](https://vorner.github.io/2020/04/09/wrapping-mental-models.html).
+* [The problem of effects in Rust](https://boats.gitlab.io/blog/post/the-problem-of-effects/).
+* [Library-ification and analyzing Rust](https://smallcultfollowing.com/babysteps/blog/2020/04/09/libraryification/).
+* [A possible new backend for Rust](https://jason-williams.co.uk/a-possible-new-backend-for-rust).
+* [Simple but powerful Pratt parsing](https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html).
+* [Ruma is dead, long live Ruma](https://www.ruma.io/news/ruma-is-dead-long-live-ruma-2020-04-10/).
+* [Programming Servo: My own private runtime](https://medium.com/programming-servo/programming-servo-my-own-private-runtime-8a5ba74c63c8).
+* [Hyper traps](https://vorner.github.io/2020/04/13/hyper-traps.html).
+* [Downloading all the crates on crates.io](https://www.pietroalbini.org/blog/downloading-crates-io/).
+* [Kubernetes: A Rusty Friendship](https://deislabs.io/posts/kubernetes-a-rusty-friendship/).
+* [Fallible Iterator Adapters](https://blog.yoshuawuyts.com/fallible-iterator-adapters/).
+* [Types over strings: Extensible architectures in Rust](http://willcrichton.net/notes/types-over-strings/).
+* [pdf] [LLHD: Rust is used to drive research in Hardware Design Languages](https://arxiv.org/pdf/2004.03494).
+* [rust-analyzer changelog 20](https://rust-analyzer.github.io/thisweek/2020/04/13/changelog-20.html).
+* [IntelliJ Rust changelog 120](https://intellij-rust.github.io/2020/04/13/changelog-120.html).
+* [New sysinfo release: processes disk usage](https://blog.guillaume-gomez.fr/articles/2020-04-09+New+sysinfo+release%3A+processes+disk+usage).
+* [April lang team design meetings](https://blog.rust-lang.org/inside-rust/2020/04/10/lang-team-design-meetings.html).
+
+Number: 335  Date: 2020-04-21 
+
+* [Rust Survey 2019 results](https://blog.rust-lang.org/2020/04/17/Rust-survey-2019.html).
+* [Testing sync at Dropbox](https://dropbox.tech/infrastructure/-testing-our-new-sync-engine).
+* [Write an OS for the Raspberry Pi in Rust](https://tc.gts3.org/cs3210/2020/spring/lab.html).
+* [Wired Logic - a pixel-based digital circuit simulator running in a browser (Rust compiled into WASM)](https://iostapyshyn.github.io/wired-logic/).
+* [Better stack fixing for Firefox](https://blog.mozilla.org/nnethercote/2020/04/15/better-stack-fixing-for-firefox/).
+* [Writing Python inside your Rust code — part 1](https://blog.m-ou.se/writing-python-inside-rust-1/).
+* [wgpu-rs on the web](https://gfx-rs.github.io/2020/04/21/wgpu-web.html).
+* [Building a Rust web browser from scratch](https://joshondesign.com/2020/03/10/rust_minibrowser).
+* [From Pratt to Dijkstra](https://matklad.github.io/2020/04/15/from-pratt-to-dijkstra.html).
+* [Rust lang tips and tricks](https://mudit.blog/rust-tips-and-tricks/).
+* [An experiment with type-erased data structures](https://vgatherps.github.io/2020-04-14-erasure/).
+* [How to write CRaP Rust code](https://blog.logrocket.com/how-to-write-crap-rust-code/).
+* [Intro to gfx-hal - part 3: Vertex buffers](https://www.falseidolfactory.com/2020/04/16/intro-to-gfx-hal-part-3-vertex-buffers.html).
+* [How I reverse engineered the LastPass CLI tool](http://adventures.michaelfbryan.com/posts/lastpass/).
+* [Open-sourcing dotenv-linter: lightning-fast tool to lint your .env files](https://evrone.com/dotenv-linter).
+* [rust-analyzer changelog 21](https://rust-analyzer.github.io/thisweek/2020/04/20/changelog-21.html).
+
+Number: 336  Date: 2020-04-29 
+
+* 🎈🎉 [Announcing Rust 1.43.0](https://blog.rust-lang.org/2020/04/23/Rust-1.43.0.html). 🎉🎈
+* [How to speed up the Rust compiler in 2020](https://blog.mozilla.org/nnethercote/2020/04/24/how-to-speed-up-the-rust-compiler-in-2020/).
+* [A taste of WebGPU in Firefox](https://hacks.mozilla.org/2020/04/experimental-webgpu-in-firefox/).
+* [Data ingestion with Rust and AWS Lambda](http://jamesmcm.github.io/blog/2020/04/19/data-engineering-with-rust-and-aws-lambda/#en).
+* [Embedded Rust pattern - zero sized references](https://ferrous-systems.com/blog/zero-sized-references/).
+* [Implementing a linear quadtree in Rust](https://snorrwe.onrender.com/posts/morton-table/).
+* [Memory efficient serialization of tagged union](https://robinmoussu.gitlab.io/blog/post/binary_serialisation_of_enum/).
+* [Unpacking Serde](https://www.reddit.com/r/rust/comments/g6ubuv/unpacking_serde_a_series_of_presentations_i_made/).
+* [video] [Rust stream: ownership, closures, and threads - oh my](https://www.youtube.com/watch?v=2mwwYbBRJSo).
+* [video] [Crust of Rust: lifetime annotations](https://www.youtube.com/watch?list=PLqbS7AVVErFiWDOAVrPt7aYmnuuOLYvOa&time_continue=2&v=rAl-9HwD858&feature=emb_logo).
+* [First impressions on Rust and WebAssembly](https://deedone.github.io/posts/rust-wasm/).
+* [From Rust to WebAssembly: Building an interactive note-taking web app with Actix & Yew](https://www.luu.io/posts/lenote).
+* [Rust’s future: internal execution](https://blog.knoldus.com/rusts-future-internal-execution/).
+* [Rust concurrency: five easy pieces](https://medium.com/@polyglot_factotum/rust-concurrency-five-easy-pieces-871f1c62906a).
+* [(Almost) lockless stream buffering](https://mcfelix.me/blog/shared-buffers/).
+* [Rust and Node.js: a match made in heaven](https://blog.logrocket.com/rust-and-node-js-a-match-made-in-heaven/).
+* [Reducing the size of a Rust GStreamer plugin](https://www.collabora.com/news-and-blog/blog/2020/04/28/reducing-size-rust-gstreamer-plugin/).
+* [Writing Python inside your Rust code — Part 2](https://blog.m-ou.se/writing-python-inside-rust-2/).
+
+Number: 337  Date: 2020-05-05 
+
+* [Async interviews: my take thus far](https://smallcultfollowing.com/babysteps/blog/2020/04/30/async-interviews-my-take-thus-far/)
+* [Multi-threaded HTTP/WebSocket server in Rust](https://sergey-melnychuk.github.io/2020/04/27/multi-threaded-http-websocket-server-in-rust/).
+* [Cheating Rank-n with Traits](https://leshow.github.io/post/cheat_rank_n/)
+* [Understanding Memory and Thread Safety Practices
+and Issues in Real-World Rust Programs](https://cseweb.ucsd.edu/~yiying/RustStudy-PLDI20.pdf)
+* [A beginners guide to gRPC with Rust](https://dev.to/anshulgoyal15/a-beginners-guide-to-grpc-with-rust-3c7o)
+* [Setup Anaconda, Jupyter, and Rust](https://shahinrostami.com/posts/programming/rust-notebooks/setup-anaconda-jupyter-and-rust/)
+* [Teleforking a process onto a different computer!](https://thume.ca/2020/04/18/telefork-forking-a-process-onto-a-different-computer/)
+* [Stubbing out WASI manually in Rust](http://www.jakubkonka.com/2020/04/28/rust-wasi-from-scratch.html)
+* [Rust Analyzer - Changelog #22](https://rust-analyzer.github.io/thisweek/2020/04/27/changelog-22.html)
+* [IntelliJ Rust changelog #121](https://intellij-rust.github.io/2020/04/27/changelog-121.html)
+* [Type-level programming in Rust](http://willcrichton.net/notes/type-level-programming/)
+* [Rust at FullStory, Part 2: A Look Inside Our Mobile SDK](https://bionic.fullstory.com/rust-at-fullstory-part-2/)
+* [Notes on Parsing in Rust](https://blog.wesleyac.com/posts/rust-parsing)
+* [Create a blazingly fast REST API in Rust (Part 1/2)](https://docs.qovery.com/guides/tutorial/create-a-blazingly-fast-api-in-rust-part-1/)
+* [The Safety Boat: Kubernetes and Rust](https://msrc-blog.microsoft.com/2020/04/29/the-safety-boat-kubernetes-and-rust/)
+* [From Pratt to Dijkstra](https://matklad.github.io//2020/04/15/from-pratt-to-dijkstra.html)
+* [Learning embedded Rust by building RISC-V-powered robot - Part 4](https://k155la3.blog/2020/04/19/learning-embedded-rust-by-building-riscv-powered-robot-part-4/)
+* [How to write CRaP Rust Code](https://blog.logrocket.com/how-to-write-crap-rust-code/)
+* [Rust concurrency: a streaming workflow, served with a side of back-pressure.](https://medium.com/@polyglot_factotum/rust-concurrency-a-streaming-workflow-served-with-a-side-of-back-pressure-955bdf0266b5)
+* [Writing a Python module in Rust using PyO3](https://kushaldas.in/posts/writing-python-module-in-rust-using-pyo3.html)
+* [Creating a Robust, Reusable Link-Checker](http://adventures.michaelfbryan.com/posts/linkchecker/)
+* [video] [Crust of Rust: Declarative Macros](https://www.youtube.com/watch?v=q6paRBbLgNw)
+* [video] [Rust Stream: String it All Together!](https://www.youtube.com/watch?v=7I11degAElQ)
+* [video] [Educational Rust live coding - Building a git CLI](https://www.youtube.com/watch?v=YFzF1AHYjes)
+* [video] [Maximum Sum of Subarrays (Leetcode) in Rust](https://www.youtube.com/watch?v=G1deF4Rehlw)
+* [video] [WASM + Rust](https://www.youtube.com/watch?list=PLDWmoWFf46gj7htqRU1yNwM3SeaqfLKhH&v=gpaNGlka7FY&feature=emb_logo)
+* [video] [Concurrency in Rust with Async/Await](https://www.youtube.com/watch?v=hrNoTZMG2MU)
+* [video] [Rust and Tell Berlin Meetup - April 2020 [video]](https://www.youtube.com/watch?v=yGuxtodWYDs)
+* [video] [Rust Zürisee, April: cargo crev and cargo audit](https://www.youtube.com/watch?v=_xS40wqO8GA)
+
+Number: 338  Date: 2020-05-12 
+
+* [Announcing Rust 1.43.1](https://blog.rust-lang.org/2020/05/07/Rust.1.43.1.html)
+* [Rust concurrency: the single-writer principle.](https://medium.com/@polyglot_factotum/rust-concurrency-the-single-writer-principle-applied-aada2cdc6fb0?source=friends_link&sk=cafc8dcf8babf4ec95b1b62ccde7e54b)
+* [This Month in Rust OSDev (April 2020)](https://rust-osdev.com/this-month/2020-04/)
+* [A no_std Rust binary](https://fasterthanli.me/blog/2020/a-no-std-rust-binary/)
+* [Notes on io_uring](https://boats.gitlab.io/blog/post/io-uring/)
+* [no_std async/await - soon on stable](https://ferrous-systems.com/blog/stable-async-on-embedded/)
+* ["try fn" without special-casing Result ](https://dev.to/cad97/try-fn-without-special-casing-result-4m5b)
+* [time_it: A case study in Rust macros](https://notes.iveselov.info/programming/time_it-a-case-study-in-rust-macros)
+* [Dynamic stylesheets and Yew](https://conradludgate.com/posts/yew-css/)
+* [A practical introduction to async programming in Rust](http://jamesmcm.github.io/blog/2020/05/06/a-practical-introduction-to-async-programming-in-rust/#en)
+* [Rust Closures in FFI](http://adventures.michaelfbryan.com/posts/rust-closures-in-ffi/)
+* [Collecting many errors from an iterator of Results](https://tarquin-the-brave.github.io/blog/posts/collecting-all-the-errors/).
+* [Auto-currying Rust Functions](https://peppe.rs/posts/auto-currying_rust_functions/)
+* [Converting bits to integers in Rust using generics](https://dev.to/citizen_stig/converting-bits-to-integers-in-rust-using-generics-2nfg)
+* [Magnifying Glasses for Rust Assembly](https://www.justanotherdot.com/posts/magnifying-glasses-for-rust-assembly.html)
+* [More Rust and Load Balancer Adventures](https://medium.com/@bparli/more-rust-and-load-balancer-adventures-fad07f4fb095) 
+* [Porting North Korean Dictionaries with Rust](https://digitalnk.com/blog/2020/05/08/porting-north-korean-dictionaries-with-rust/)
+* [Rust verification tools](https://alastairreid.github.io/rust-verification-tools/)
+* [Series Announcement - Zero to Production in Rust](https://www.lpalmieri.com/posts/2020-05-10-announcement-zero-to-production-in-rust/)
+* [What I Learned Contributing to Rust-Analyzer](https://dev.to/bnjjj/what-i-learned-contributing-to-rust-analyzer-4c7e)
+* [What’s the difference between a Rust char and a Go rune?](https://www.christianfscott.com/rust-chars-vs-go-runes/)
+* [Writing A Wayland Compositor In Rust](https://wiki.alopex.li/WritingAWaylandCompositorInRust)
+* [Yak shaving conditional compilation in Rust](https://bitshifter.github.io/2020/05/07/conditional-compilation-in-rust/)
+* [Oxidize Global Workshop and CfP announcement](https://ferrous-systems.com/blog/oxidize-global-workshop-and-cfp-announcement/)
+* [Collecting many errors from an iterator of Results](https://tarquin-the-brave.github.io/blog/posts/collecting-all-the-errors/).
+* [Writing Python inside your Rust code - Part 3](https://blog.m-ou.se/writing-python-inside-rust-3/)
+* [Rust FFI - Building an ASN1 codec](https://sjames.github.io/articles/2020-04-26-rust-ffi-asn1-codec/)
+* [video] [Building a simple GraphQL API with Actix and Juniper](https://youtu.be/7v7ERnrC4fo)
+* [video] [Named Field Init in C, C++20, Zig, Rust, & D](https://www.youtube.com/watch?v=c-NyXKbqmQc)
+
+Number: 339  Date: 2020-05-19 
+
+* [Five Years of Rust](https://blog.rust-lang.org/2020/05/15/five-years-of-rust.html)
+* [Structuring and handling errors in 2020](https://nick.groenen.me/posts/rust-error-handling/)
+* [Taking Advantage of Auto-Vectorization in Rust](https://nickwilcox.github.io/blog/autovec/)
+* [State of Web Routing in Rust](https://pksunkara.com/posts/state-of-routing-in-rust/)
+* [Rust releases for single and multiple targets with GitHub Actions](https://mateuscosta.me/rust-releases-with-github-actions)
+* [Getting Started With Rust By Building A Tiny Markdown Compiler](https://jesselawson.org/rust/getting-started-with-rust-by-building-a-tiny-markdown-compiler/)
+* [Parcel and Rust: A WASM Romcom](https://dev.to/potatostudios_/parcel-and-rust-a-wasm-romcom-545e)
+* [Reading temperature sensor in Rust using Raspberry Pi GPIO](https://dev.to/citizen_stig/reading-temperature-sensor-in-rust-using-raspberry-pi-gpio-bhf)
+* [Rust Analyzer - Next Few Years](https://rust-analyzer.github.io/blog/2020/05/18/next-few-years.html)
+* [Rust Closures in FFI](http://adventures.michaelfbryan.com/posts/rust-closures-in-ffi/)
+* [Taking Advantage of Auto-Vectorization in Rust](https://nickwilcox.github.io/blog/autovec/)
+* [The case for using Rust for Automotive Software](https://medium.com/@sojan.james/the-case-for-using-rust-for-automotive-software-19400779f126)
+* [Gamedev #4: Benefits of full-stack Rust](https://www.jakobmeier.ch/blogging/Paddlers_4.html)
+* [RISC-V OS using Rust Chapter 9: Block IO](http://osblog.stephenmarz.com/ch9.html)
+* [A Guide to Global Data in Rust](https://github.com/paulkernfeld/global-data-in-rust)
+* [audio] [What's New in Rust 1.42 and 1.43](https://rustacean-station.org/episode/014-rust-1.42-1.43/)
+* [video] [Jonathan Teaches Jason Rust!](https://www.youtube.com/watch?v=EzQ7YIIo1rY&feature=youtu.be)
+* [video] [Educational Rust coding - Building a web app](https://www.twitch.tv/videos/623988324)
+* [video] [Rust and C++ Cardiff Virtual Meetup](https://www.youtube.com/watch?v=s8WMaVU3EBs&feature=youtu.be)
+


### PR DESCRIPTION
I don't know if this is right idea to include a backup text file of links in `News and Blog` section of previous TWiR articles.
This file contains links from TWir 96 ( 2015-09-14  ) to TWiR 339  ( 2020-05-19 ).

If you don't like this idea feel free to close this PR.

Here is the [raw](https://raw.githubusercontent.com/hmble/news_blog/master/links.txt) file I mention in issue #1222 for reference as this diff is quite large. 