### PR TITLE
Add blog post for Writing Interpreters in Rust online book

### DIFF
--- a/draft/2020-07-07-this-week-in-rust.md
+++ b/draft/2020-07-07-this-week-in-rust.md
@@ -18,7 +18,7 @@ Check out [this week's *This Week in Rust Podcast*]()
 
 ## News & Blog Posts
 
-* [About a new WIP online book - "Writing Interpreters in Rust: a Guide"](https://pliniker.github.io/post/rust-hosted-langs/)
+* [Writing Interpreters in Rust: a Guide](https://pliniker.github.io/post/rust-hosted-langs/)
 
 # Crate of the Week
 

--- a/draft/2020-07-07-this-week-in-rust.md
+++ b/draft/2020-07-07-this-week-in-rust.md
@@ -18,6 +18,8 @@ Check out [this week's *This Week in Rust Podcast*]()
 
 ## News & Blog Posts
 
+* [About a new WIP online book - "Writing Interpreters in Rust: a Guide"](https://pliniker.github.io/post/rust-hosted-langs/)
+
 # Crate of the Week
 
 This week's crate is [print_bytes](https://crates.io/crates/print_bytes), a library to print arbitrary bytes to a stream as losslessly as possible.


### PR DESCRIPTION
Blog post: https://pliniker.github.io/post/rust-hosted-langs/
The WIP book: https://rust-hosted-langs.github.io/book/
The book source: https://github.com/rust-hosted-langs/book

Thanks!