### PR TITLE
boa 0.9 uses Rust's measureme

### DIFF
--- a/draft/2020-07-07-this-week-in-rust.md
+++ b/draft/2020-07-07-this-week-in-rust.md
@@ -18,6 +18,8 @@ Check out [this week's *This Week in Rust Podcast*]()
 
 ## News & Blog Posts
 
+* [Boa release v0.9 and make use of Rust's measureme](https://boa-dev.github.io/2020/07/03/boa-release-09.html)
+
 # Crate of the Week
 
 This week's crate is [print_bytes](https://crates.io/crates/print_bytes), a library to print arbitrary bytes to a stream as losslessly as possible.


### PR DESCRIPTION
Boa releases v0.9 and is the first project to make use of the Rust compiler team's [measureme](https://github.com/rust-lang/measureme).

In this post Boa goes through it's use of measureme's tools including `summarize` and `crox` to show where time is being spent. Boa identified areas of improvement this release and brought startup times down by over 70%.

https://www.reddit.com/r/rust/comments/hkifvb/boa_v09_measureme_optimisations/