### PR TITLE
Add post about kernel modules in Rust

### DIFF
--- a/draft/2020-07-07-this-week-in-rust.md
+++ b/draft/2020-07-07-this-week-in-rust.md
@@ -18,6 +18,7 @@ Check out [this week's *This Week in Rust Podcast*]()
 
 ## News & Blog Posts
 
+* [Transpiling A Kernel Module to Rust: The Good, the Bad and the Ugly](https://immunant.com/blog/2020/06/kernel_modules/)
 * [Writing Interpreters in Rust: a Guide](https://pliniker.github.io/post/rust-hosted-langs/)
 * [Bad Apple!! and how I wrote a Rust video player for Task Manager!!](https://www.azabani.com/2020/06/29/bad-apple-for-taskmgr.html)
 * [Boa release v0.9 and make use of Rust's measureme](https://boa-dev.github.io/2020/07/03/boa-release-09.html)


### PR DESCRIPTION
Link to our latest blog post on transpiling kernel modules to Rust.