### PR TITLE
Add link to Contributing to IntelliJ Rust blog post

### DIFF
--- a/draft/2020-08-25-this-week-in-rust.md
+++ b/draft/2020-08-25-this-week-in-rust.md
@@ -19,6 +19,7 @@ Check out [this week's *This Week in Rust Podcast*](https://rustacean-station.or
 ### Official
 
 ### Tooling
+* [Contributing to the IntelliJ Rust plugin](https://kobzol.github.io/rust/intellij/2020/07/31/contributing-0-setup.html)
 
 ### Newsletters
 


### PR DESCRIPTION
Adds link to my blog post about contributing to the IntelliJ Rust plugin.