### PR TITLE
Added article about generating static arrays during compile time.

### DIFF
--- a/draft/2020-09-02-this-week-in-rust.md
+++ b/draft/2020-09-02-this-week-in-rust.md
@@ -26,6 +26,8 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 
 ### Learn More Rust
 
+[Generating static arrays during compile time in Rust](https://dev.to/rustyoctopus/generating-static-arrays-during-compile-time-in-rust-10d8)
+
 ### Project Updates
 
 ### Miscellaneous


### PR DESCRIPTION
PR for my article about generating static arrays during compile time. I explore 4 options to do this (constant functions, macro rules macros, build scripts, procedural macros). Although I am using standard Rust functionality I think it fits better into the "learn more rust" section.