### PR TITLE
Add link to Contributing to IntelliJ: Writing an intention

### DIFF
--- a/draft/2020-09-02-this-week-in-rust.md
+++ b/draft/2020-09-02-this-week-in-rust.md
@@ -17,6 +17,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 ### Official
 
 ### Tooling
+[Contributing to the IntelliJ Rust plugin: Writing an intention](https://kobzol.github.io/rust/intellij/2020/08/25/contributing-2-subst-assoc-type-int.html)
 
 ### Newsletters
 


### PR DESCRIPTION
I wrote another blog post on contributing to the IntelliJ Rust plugin. I don't know what's your stance on including the same blog series (with newer posts) in TWIR, if you think it's too repeating, feel free to close this.