### PR TITLE
Remove timestamp in Choosing Rust video link

### DIFF
--- a/draft/2020-09-09-this-week-in-rust.md
+++ b/draft/2020-09-09-this-week-in-rust.md
@@ -25,7 +25,7 @@ If you find any errors in this week's issue, [please submit a PR](https://github
 * [Retrospective of my first useful Rust project](http://jamesmcm.github.io/blog/2020/09/05/vopono/#en)
 
 ### Learn Standard Rust
-* [video] [Choosing Rust - Intro to Rust and Ownership](https://www.youtube.com/watch?v=DMAnfOlhSpU&t=206s)
+* [video] [Choosing Rust - Intro to Rust and Ownership](https://www.youtube.com/watch?v=DMAnfOlhSpU)
 
 ### Learn More Rust
 


### PR DESCRIPTION
Sorry! My link had a timestamp in it.