### PR TITLE
Add "Porting EBU-R128 audio loudness analysis from C to Rust"

### DIFF
--- a/draft/2020-09-23-this-week-in-rust.md
+++ b/draft/2020-09-23-this-week-in-rust.md
@@ -22,6 +22,8 @@ No newsletters this week.
 
 ### Observations/Thoughts
 
+ * [Porting EBU-R128 audio loudness analysis from C to Rust](https://coaxion.net/blog/2020/09/porting-ebu-r128-audio-loudness-analysis-from-c-to-rust/)
+
 ### Learn Standard Rust
 
 ### Learn More Rust


### PR DESCRIPTION
Not sure if that's best under "Observations/Thoughts" or further down under "Misc". This is the initial blog post of a 4-part series about porting some C code to Rust. This part is the general overview, the next parts would fit best under "Learn More Rust".

Feel free to move it where you think it fits better :)